### PR TITLE
clearing the feeddata so it actually gets new data on load

### DIFF
--- a/src/components/NotificationDropdown.js
+++ b/src/components/NotificationDropdown.js
@@ -78,42 +78,38 @@ class NotificationDropdownInner extends React.Component<PropsInner, State> {
     this.dropdownRef = React.createRef();
   }
 
-  _refresh = async () => {
-    await this.props.refresh(makeDefaultOptions(this.props.options));
-  };
-
-  openDropdown = () => {
-    this._refresh();
+  clickHandler = () => {
     this.setState(
       {
-        open: true,
+        open: !this.state.open,
       },
       () => {
-        //$FlowFixMe
-        document.addEventListener('click', this.closeDropdown, false);
+        if (this.state.open) {
+          //$FlowFixMe
+          document.addEventListener('click', this.documentClickHandler, false);
+        } else {
+          //$FlowFixMe
+          document.removeEventListener(
+            'click',
+            this.documentClickHandler,
+            false,
+          );
+        }
       },
     );
   };
 
-  closeDropdown = (e) => {
+  documentClickHandler = (e) => {
     if (
       this.dropdownRef.current !== null &&
-      !this.dropdownRef.current.contains(e.target)
+      !this.dropdownRef.current.contains(e.target) &&
+      this.state.open
     ) {
-      this.setState(
-        {
-          open: false,
-        },
-        () => {
-          //$FlowFixMe
-          document.removeEventListener('click', this.closeDropdown, false);
-        },
-      );
+      this.clickHandler();
     }
   };
 
   componentDidMount() {
-    // get
     this.props.refreshUnreadUnseen();
   }
 
@@ -127,7 +123,7 @@ class NotificationDropdownInner extends React.Component<PropsInner, State> {
       <div style={{ position: 'relative', display: 'inline-block' }}>
         <IconBadge
           unseen={this.props.unseen}
-          onClick={this.openDropdown}
+          onClick={this.clickHandler}
           showNumber={true}
           hidden={!this.props.notify}
         />
@@ -148,14 +144,11 @@ class NotificationDropdownInner extends React.Component<PropsInner, State> {
             transition: 'all .2s ease-out',
           }}
         >
-          <DropdownPanel arrow right={this.props.right}>
-            {this.state.open && (
-              <NotificationFeed
-                notify={this.props.notify}
-                options={{ mark_seen: true }}
-              />
-            )}
-          </DropdownPanel>
+          {this.state.open && (
+            <DropdownPanel arrow right={this.props.right}>
+              <NotificationFeed Notifier={null} options={{ mark_seen: true }} />
+            </DropdownPanel>
+          )}
         </div>
       </div>
     );

--- a/src/components/NotificationFeed.js
+++ b/src/components/NotificationFeed.js
@@ -91,6 +91,11 @@ class NotificationFeedInner extends React.Component<PropsInner> {
     await this._refresh();
   }
 
+  componentWillUnmount() {
+    this.props.activities.clear();
+    this.props.activityOrder.splice(0, this.props.activityOrder.length);
+  }
+
   _renderWrappedGroup = ({ item }: { item: any }) => (
     <ImmutableItemWrapper
       renderItem={this._renderGroup}


### PR DESCRIPTION
Hey @JelteF we're running into a problem where the NotificationDropdown doesn't actually rerender the feed upon mounting and unmounting. We added the following code to the NotificationFeed but it doesnt seem like the nicest way to actually do this:

```
componentWillUnmount() {
    this.props.activities.clear();
    this.props.activityOrder.splice(0, this.props.activityOrder.length);
}
```

What do you think?