### PR TITLE
Update utils.js for aggregated feeds

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -60,7 +60,7 @@ export function userOrDefault(
     updated_at: '',
     data: { name: 'Unknown', profileImage: '' },
   };
-  if (typeof user === 'string' || typeof user.error === 'string') {
+  if (!user || typeof user === 'string' || typeof user.error === 'string') {
     actor = notFound;
   } else {
     //$FlowBug


### PR DESCRIPTION
`userOrDefault` in utils.js is called for actors as well, and gives an error when actor is of string type (and `actor.error` cannot exist). This fixes for a broader range of types.