### PR TITLE
fixes #101: Upgrade emoji-mart to fix babel error

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@webscopeio/react-textarea-autocomplete": "^4.0.0",
     "anchorme": "^1.1.2",
     "dayjs": "^1.8.23",
-    "emoji-mart": "^2.8.1",
+    "emoji-mart": "^3.0.0",
     "eslint-plugin-markdown": "^1.0.0",
     "getstream": "^5.0.0",
     "i18next": "^19.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5007,11 +5007,12 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-emoji-mart@^2.8.1:
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/emoji-mart/-/emoji-mart-2.11.1.tgz#fc9330b513803c17b98c9ad289c12ab61ff05f8f"
-  integrity sha512-Hr4N56YEkaPtmojO2dfgnMLLE/d5HpnhH0+M8cw9LRHpG2EgQQaCelRad3d5qQAPHI5+K0wMc/rwM0eRo0FnUA==
+emoji-mart@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-mart/-/emoji-mart-3.0.0.tgz#eca24a04881e27752a6921e09f65a86ce8539a50"
+  integrity sha512-r5DXyzOLJttdwRYfJmPq/XL3W5tiAE/VsRnS0Hqyn27SqPA/GOYwVUSx50px/dXdJyDSnvmoPbuJ/zzhwSaU4A==
   dependencies:
+    "@babel/runtime" "^7.0.0"
     prop-types "^15.6.0"
 
 "emoji-regex@>=6.0.0 <=6.1.1":


### PR DESCRIPTION
The react-activity-feed library was throwing a runtime error (`Module not found: Error: Can't resolve 'babel-runtime/core-js/json/stringify'`). Upgrading the emoji-mart dependency to its current version (^3.0.0) solves this.