### PR TITLE
Documentation fix

### DIFF
--- a/src/components/Activity.tsx
+++ b/src/components/Activity.tsx
@@ -21,7 +21,7 @@ export type ActivityProps<
    * used to initialize the toggle state and the counter. */
   activity: EnrichedActivity<UT, AT, CT, RT, CRT>;
   /** Content component to display.
-   * #DefaultActivityContent (Component)#
+   * #ActivityContent (Component)#
    */
   Content?: ElementOrComponentOrLiteralType<ActivityContentProps<UT, AT, CT, RT, CRT>>;
   /** The feed group part of the feed that the activity should be reposted to
@@ -30,7 +30,7 @@ export type ActivityProps<
   feedGroup?: string;
   Footer?: ElementOrComponentOrLiteralType<ActivityFooterProps<UT, AT, CT, RT, CRT>>;
   /** Header component to display.
-   * #DefaultActivityHeader (Component)#
+   * #ActivityHeader (Component)#
    */
   Header?: ElementOrComponentOrLiteralType<ActivityHeaderProps<UT, AT>>;
   HeaderRight?: ElementOrComponentOrLiteralType;
@@ -41,7 +41,7 @@ export type ActivityProps<
   onClickMention?: WordClickHandler;
   onClickUser?: (user: UserOrDefaultReturnType<UT>) => void;
   /** UI component to render original activity within a repost
-   * #DefaultRepost (Component)#
+   * #Repost (Component)#
    */
   Repost?: ElementOrComponentOrLiteralType<ActivityProps<UT, AT, CT, RT, CRT>>;
   /** The user_id part of the feed that the activity should be reposted to when

--- a/src/components/Activity.tsx
+++ b/src/components/Activity.tsx
@@ -20,12 +20,18 @@ export type ActivityProps<
   /** The activity received for stream for which to show the like button. This is
    * used to initialize the toggle state and the counter. */
   activity: EnrichedActivity<UT, AT, CT, RT, CRT>;
+  /** Content component to display.
+   * #DefaultActivityContent (Component)#
+   */
   Content?: ElementOrComponentOrLiteralType<ActivityContentProps<UT, AT, CT, RT, CRT>>;
   /** The feed group part of the feed that the activity should be reposted to
    * when pressing the RepostButton, e.g. `user` when posting to your own profile
    * defaults to 'user' feed */
   feedGroup?: string;
   Footer?: ElementOrComponentOrLiteralType<ActivityFooterProps<UT, AT, CT, RT, CRT>>;
+  /** Header component to display.
+   * #DefaultActivityHeader (Component)#
+   */
   Header?: ElementOrComponentOrLiteralType<ActivityHeaderProps<UT, AT>>;
   HeaderRight?: ElementOrComponentOrLiteralType;
   icon?: string;
@@ -34,7 +40,9 @@ export type ActivityProps<
   /** Handler for any routing you may do on clicks on Mentions */
   onClickMention?: WordClickHandler;
   onClickUser?: (user: UserOrDefaultReturnType<UT>) => void;
-  /** UI component to render original activity within a repost */
+  /** UI component to render original activity within a repost
+   * #DefaultRepost (Component)#
+   */
   Repost?: ElementOrComponentOrLiteralType<ActivityProps<UT, AT, CT, RT, CRT>>;
   /** The user_id part of the feed that the activity should be reposted to when
    * pressing the RepostButton */

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -22,14 +22,18 @@ export type CommentListProps<
   /** Only needed for reposted activities where you want to show the comments
    * of the original activity, not of the repost */
   activityPath?: Array<string>;
-  /** The component that should render the comment */
+  /** The component that should render the comment
+   * #CommentItem (Component)#
+   */
   CommentItem?: ElementOrComponentOrLiteralType<CommentItemProps<UT, RT, CRT>>;
   /** Show and load comments starting with the oldest reaction first, instead
    * of the default where comments are displayed and loaded most recent first.
    */
   oldestToNewest?: boolean;
   /** By default pagination is done with a "Load more" button, you can use
-   * InfiniteScrollPaginator to enable infinite scrolling */
+   * [InfiniteScrollPaginator](/components/infinite-scroll) to enable infinite scrolling
+   * #LoadMorePaginator (Component)#
+   */
   Paginator?: ElementOrComponentOrLiteralType<LoadMorePaginatorProps>;
   /** Reverse the order the comments are displayed in. */
   reverseOrder?: boolean;

--- a/src/components/Dropdown.mdx
+++ b/src/components/Dropdown.mdx
@@ -3,15 +3,11 @@ route: /components/dropdown
 menu: Composition Components
 ---
 
-import { Playground, Props } from 'docz';
+import { Playground } from 'docz';
 import { Dropdown } from './Dropdown';
 import { Link } from './Link';
 
 # Dropdown
-
-## Properties
-
-<Props of={Dropdown} />
 
 ## Basic usage
 

--- a/src/components/FlatFeed.tsx
+++ b/src/components/FlatFeed.tsx
@@ -24,16 +24,26 @@ type FlatFeedInnerProps<
   RT extends UR = UR,
   CRT extends UR = UR
 > = {
-  /** The component used to render an activity in the feed */
+  /** The component used to render an activity in the feed
+   * #Activity (Component)#
+   */
   Activity: ElementOrComponentOrLiteralType<ActivityProps<UT, AT, CT, RT, CRT>>;
-  /** Component to show when the feed is refreshing **/
+  /** Component to show when the feed is refreshing
+   * #LoadingIndicator (Component)#
+   */
   LoadingIndicator: ElementOrComponentOrLiteralType<LoadingIndicatorProps>;
-  /** The component to use to render new activities notification */
+  /** The component to use to render new activities notification
+   * #Notifier (NewActivitiesNotification Component)#
+   */
   Notifier: ElementOrComponentOrLiteralType<NewActivitiesNotificationProps>;
   /** By default pagination is done with a "Load more" button, you can use
-   * InfiniteScrollPaginator to enable infinite scrolling */
+   * [InfiniteScrollPaginator](/components/infinite-scroll) to enable infinite scrolling
+   * #LoadMorePaginator (Component)#
+   */
   Paginator: ElementOrComponentOrLiteralType<LoadMorePaginatorProps>;
-  /** Component to show when there are no activities in the feed **/
+  /** Component to show when there are no activities in the feed
+   * #FeedPlaceholder (Component)#
+   */
   Placeholder: ElementOrComponentOrLiteralType<FeedPlaceholderProps>;
   /** Read options for the API client (eg. limit, ranking, ...) */
   options?: FeedProps['options'];

--- a/src/components/LoadMorePaginator.tsx
+++ b/src/components/LoadMorePaginator.tsx
@@ -9,7 +9,9 @@ export type LoadMorePaginatorProps = {
   hasNextPage: boolean;
   /** callback to load the next page */
   loadNextPage: LoadMoreButtonProps['onClick'];
-  /** The button the user should click to click to load more */
+  /** The button the user should click to click to load more
+   * #LoadMoreButton (Component)#
+   */
   LoadMoreButton?: ElementOrComponentOrLiteralType<LoadMoreButtonProps>;
   /** indicates if there there's currently any refreshing taking place */
   refreshing?: boolean;

--- a/src/components/NotificationFeed.tsx
+++ b/src/components/NotificationFeed.tsx
@@ -16,15 +16,26 @@ type NotificationFeedInnerProps<
   RT extends UR = UR,
   CRT extends UR = UR
 > = {
-  /** the component used to render a grouped notifications in the feed */
+  /** the component used to render a grouped notifications in the feed
+   * #Notification (Component)#
+   */
   Group: ElementOrComponentOrLiteralType<NotificationProps<UT, AT, CT, RT, CRT>>;
-  /** Component to show when the feed is refreshing **/
+  /** Component to show when the feed is refreshing
+   * #LoadingIndicator (Component)#
+   */
   LoadingIndicator: ElementOrComponentOrLiteralType<LoadingIndicatorProps>;
-  /** The component to use to render new activities notification */
+  /** The component to use to render new activities notification
+   * #NewActivitiesNotification (Component)#
+   */
   Notifier: ElementOrComponentOrLiteralType<NewActivitiesNotificationProps>;
-  /** By default pagination is done with a "Load more" button, you can use InfiniteScrollPaginator to enable infinite scrolling */
+  /** By default pagination is done with a "Load more" button, you can use
+   * [InfiniteScrollPaginator](/components/infinite-scroll) to enable infinite scrolling
+   * #LoadMorePaginator (Component)#
+   */
   Paginator: ElementOrComponentOrLiteralType<LoadMorePaginatorProps>;
-  /** Component to show when there are no activities in the feed **/
+  /** Component to show when there are no activities in the feed
+   * #FeedPlaceholder (Component)#
+   */
   Placeholder: ElementOrComponentOrLiteralType<FeedPlaceholderProps>;
   /** Read options for the API client (eg. limit, ranking, ...) */
   options?: FeedProps['options'];

--- a/src/components/ReactionList.tsx
+++ b/src/components/ReactionList.tsx
@@ -20,7 +20,9 @@ export type ReactionListType<UT extends DefaultUT = DefaultUT, RT extends UR = U
    * of the default where reactions are displayed and loaded most recent first. */
   oldestToNewest?: boolean;
   /** By default pagination is done with a "Load more" button, you can use
-   * InfiniteScrollPaginator to enable infinite scrolling */
+   * [InfiniteScrollPaginator](/components/infinite-scroll) to enable infinite scrolling
+   * #LoadMorePaginator (Component)#
+   */
   Paginator?: ElementOrComponentOrLiteralType<LoadMorePaginatorProps>;
   /** Reverse the order the reactions are displayed in. */
   reverseOrder?: boolean;

--- a/src/components/StatusUpdateForm/StatusUpdateForm.tsx
+++ b/src/components/StatusUpdateForm/StatusUpdateForm.tsx
@@ -31,8 +31,7 @@ export type StatusUpdateFormProps<AT extends DefaultAT = DefaultAT> = {
   /** Override Post request */
   doRequest?: (activity: NewActivity<AT>) => Promise<Activity<AT>>;
   /** Override the default emoji dataset, library has a light set of emojis
-   * to show more emojis use your own or emoji-mart sets
-   * https://github.com/missive/emoji-mart#datasets
+   * to show more emojis use your own or [emoji-mart sets](https://github.com/missive/emoji-mart#datasets)
    */
   emojiData?: EmojiPickerProps['emojiData'];
   /** The feed group part of the feed that the activity should be posted to, default to "user" */

--- a/src/gatsby-theme-docz/components/Props/index.js
+++ b/src/gatsby-theme-docz/components/Props/index.js
@@ -1,0 +1,118 @@
+/** @jsx jsx */
+import { useState, useMemo, Children } from 'react';
+import { jsx } from 'theme-ui';
+
+import * as styles from './styles';
+
+export const ChevronDown = (props) => (
+  <svg
+    aria-hidden="true"
+    data-icon="chevron-down"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 448 512"
+    {...props}
+  >
+    <path
+      fill="currentColor"
+      d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"
+    ></path>
+  </svg>
+);
+
+export const ChevronUp = (props) => (
+  <svg
+    aria-hidden="true"
+    data-icon="chevron-up"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 448 512"
+    {...props}
+  >
+    <path
+      fill="currentColor"
+      d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+    ></path>
+  </svg>
+);
+
+// our interpretation of default value looks like: #your-default-value-text#
+const isDefaultValue = (text = '') => typeof text === 'string' && text.startsWith('#') && text.endsWith('#');
+const removeDefaultValues = (children) =>
+  Children.toArray(children).filter((v) => (v?.props?.children || []).some((v) => !isDefaultValue(v)));
+
+export const getDefaultValue = ({ defaultValue, type, flowType, description }) => {
+  const texts = Children.toArray(description)
+    .map((v) => v?.props?.children)
+    .flat(Infinity);
+
+  const descriptionValue = texts.find(isDefaultValue);
+
+  if (descriptionValue) return descriptionValue.replaceAll('#', '');
+
+  const propType = flowType ? flowType : type;
+  if (!defaultValue || !defaultValue.value) return null;
+  if (defaultValue.value === "''") {
+    return '[Empty string]';
+  }
+  if (propType && propType.name === 'string') {
+    return defaultValue.value.replace(/'/g, '"');
+  }
+  if (typeof defaultValue.value === 'object' && defaultValue.value.toString) {
+    return defaultValue.value.toString();
+  }
+  return defaultValue.value;
+};
+
+export const Prop = ({ propName, prop, getPropType, isToggle }) => {
+  const [showing, setShowing] = useState(isToggle || false);
+  if (!prop.type && !prop.flowType) return null;
+
+  const toggle = () => setShowing((s) => !s);
+  return (
+    <div sx={styles.line} data-testid="prop">
+      <div sx={styles.content}>
+        <div sx={styles.propName} data-testid="prop-name">
+          {propName}
+        </div>
+        <div sx={styles.propType} data-testid="prop-type">
+          {getPropType(prop)}
+        </div>
+        {prop.defaultValue && (
+          <div sx={styles.defaultValue} data-testid="prop-default-value">
+            <em>{getDefaultValue(prop)}</em>
+          </div>
+        )}
+        <div sx={styles.right}>
+          {prop.required && (
+            <div sx={styles.propRequired} data-testid="prop-required">
+              <strong>required</strong>
+            </div>
+          )}
+          {prop.description && (
+            <button sx={styles.openDescBtn} onClick={toggle} data-testid="prop-toggle-description">
+              {showing ? <ChevronUp style={{ height: 20 }} /> : <ChevronDown style={{ height: 20 }} />}
+            </button>
+          )}
+        </div>
+      </div>
+      {showing && prop.description && (
+        <div sx={styles.description} data-testid="prop-description">
+          {removeDefaultValues(prop.description)}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const Props = ({ props, getPropType, isToggle }) => {
+  const entries = useMemo(() => Object.entries(props), [props]);
+
+  return (
+    <div sx={styles.container} data-testid="props">
+      {entries.map(([key, prop]) => (
+        <Prop key={key} propName={key} prop={prop} getPropType={getPropType} isToggle={isToggle} />
+      ))}
+    </div>
+  );
+};

--- a/src/gatsby-theme-docz/components/Props/styles.js
+++ b/src/gatsby-theme-docz/components/Props/styles.js
@@ -1,0 +1,110 @@
+const mixins = {
+  centerAlign: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ghostButton: {
+    p: 0,
+    outline: 'none',
+    background: 'transparent',
+    border: 'none',
+    ':hover': {
+      cursor: 'pointer',
+    },
+  },
+};
+
+export const breakpoints = {
+  mobile: 630,
+  tablet: 920,
+  desktop: 1120,
+};
+
+export const container = {
+  mt: 3,
+  mb: 4,
+  border: (t) => `1px solid ${t.colors.border}`,
+  borderRadius: 'radius',
+  overflow: 'hidden',
+  bg: 'props.bg',
+  color: 'props.text',
+  fontSize: 3,
+};
+
+export const content = {
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  [`@media (min-width: ${breakpoints.tablet}px)`]: {
+    flexWrap: 'nowrap',
+    flexDirection: 'row',
+  },
+};
+
+export const line = {
+  pt: 2,
+  '& + &': {
+    borderTop: (t) => `1px solid ${t.colors.border}`,
+  },
+};
+
+const column = {
+  //   minWidth: 0,
+  pb: 2,
+  px: 3,
+  '& ~ &': {
+    bg: 'red',
+  },
+};
+
+export const propName = {
+  ...column,
+  color: 'props.highlight',
+};
+
+export const propType = {
+  ...column,
+  color: 'props.text',
+};
+
+export const defaultValue = {
+  ...column,
+  color: 'props.defaultValue',
+};
+
+export const right = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  px: 3,
+  flex: 1,
+  [`@media (max-width: ${breakpoints.tablet}px)`]: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+  },
+};
+
+export const propRequired = {
+  color: 'props.text',
+  fontSize: 1,
+  opacity: 0.5,
+};
+
+export const openDescBtn = {
+  ...mixins.ghostButton,
+  mt: 0,
+  ml: 3,
+  color: 'props.defaultValue',
+};
+
+export const description = {
+  fontSize: 2,
+  m: 0,
+  py: 2,
+  px: 3,
+  borderTop: (t) => `1px solid ${t.colors.border}`,
+  color: 'props.descriptionText',
+  bg: 'props.descriptionBg',
+};


### PR DESCRIPTION
Added documentation fix where now all of the default values that are components are defined with `#default-value-like-directive#` in type definition so the parser can pick it up as description and I can parse it later and use it instead of that unreadable thing that was there before.