### PR TITLE
Added feedGroup as dependency to certain effects

### DIFF
--- a/src/components/FlatFeed.tsx
+++ b/src/components/FlatFeed.tsx
@@ -98,7 +98,7 @@ const FlatFeedInner = <
 
   useEffect(() => {
     refreshFeed();
-  }, []);
+  }, [feed.feedGroup]);
 
   if (feed.refreshing && !feed.hasDoneRequest) {
     return <div className="raf-loading-indicator">{smartRender<LoadingIndicatorProps>(LoadingIndicator)}</div>;

--- a/src/context/Feed.tsx
+++ b/src/context/Feed.tsx
@@ -164,7 +164,7 @@ export function Feed<
       sharedFeedManagers[feedId] ||
       new FeedManager<UT, AT, CT, RT, CRT, PT>({ ...props, analyticsClient, client, user, errorHandler })
     );
-  }, []);
+  }, [feedGroup]);
 
   useEffect(() => {
     const forceUpdate = () => setForceUpdateState((prevState) => prevState + 1);


### PR DESCRIPTION
Some effects were missing `feedGroup` in their dependency arrays and that caused application to not reload content after feed group change. This PR addresses this issue.


https://user-images.githubusercontent.com/43254280/118894840-4d6e9580-b905-11eb-8630-a0be4597c2be.mov

