### PR TITLE
Moved tslib package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "stylelint-config-standard": "^22.0.0",
     "stylelint-scss": "^3.19.0",
     "ts-jest": "^26.5.5",
-    "tslib": "^2.2.0",
     "typescript": "^4.2.4"
   },
   "dependencies": {
@@ -134,6 +133,7 @@
     "react-file-utils": "^1.0.3",
     "react-image-lightbox": "^5.1.1",
     "stream-analytics": "^3.4.2",
+    "tslib": "^2.2.0",
     "url-parse": "^1.5.1",
     "use-debounce": "^6.0.1"
   },


### PR DESCRIPTION
Moved `tslib` package from `devDependencies` to `dependencies` to address issue #265.