### PR TITLE
Added ActivityHeader export

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ export * from './components/InfiniteScrollPaginator';
 export * from './components/LoadMorePaginator';
 
 // Activity sub components
+export * from './components/ActivityHeader';
 export * from './components/ActivityFooter';
 export * from './components/AttachedActivity';
 export * from './components/UserBar';


### PR DESCRIPTION
Added the `ActivityHeader` to exports. Couldn't find a contribution guide so close, modify, or whatever is needed. Just want to bring this up.

The ActivityFooterProps seem to be accessible while ActivityHeaderProps is not. This is an issue when extending Prop interfaces. 

`import { ✅  ActivityFooterProps, ❌  ActivityHeaderProps } from "react-activity-feed"`
`import { ✅  ActivityFooter, ❌  ActivityHeader } from "react-activity-feed"`