### PR TITLE
Added userId to effect dependency arrays, fixed FM unsubscribe method

### DIFF
--- a/src/components/FlatFeed.tsx
+++ b/src/components/FlatFeed.tsx
@@ -98,7 +98,7 @@ const FlatFeedInner = <
 
   useEffect(() => {
     refreshFeed();
-  }, [feed.feedGroup]);
+  }, [feed.feedGroup, feed.userId]);
 
   if (feed.refreshing && !feed.hasDoneRequest) {
     return <div className="raf-loading-indicator">{smartRender<LoadingIndicatorProps>(LoadingIndicator)}</div>;

--- a/src/components/NotificationFeed.tsx
+++ b/src/components/NotificationFeed.tsx
@@ -92,7 +92,7 @@ const NotificationFeedInner = <
       feed.activities.clear();
       feed.activityOrder.splice(0, feed.activityOrder.length);
     };
-  }, []);
+  }, [feed.feedGroup, feed.userId]);
 
   if (feed.refreshing && !feed.hasDoneRequest) {
     return <div className="raf-loading-indicator">{smartRender<LoadingIndicatorProps>(LoadingIndicator)}</div>;
@@ -135,8 +135,8 @@ export const NotificationFeed = <
   CRT extends UR = UR,
   PT extends UR = UR
 >({
-  userId,
   options,
+  userId,
   analyticsLocation,
   doFeedRequest,
   doActivityDeleteRequest,
@@ -145,8 +145,8 @@ export const NotificationFeed = <
   doReactionAddRequest,
   doReactionDeleteRequest,
   feedGroup = 'notification',
-  Group = Notification,
   notify = false,
+  Group = Notification,
   Notifier = NewActivitiesNotification,
   Paginator = LoadMorePaginator,
   Placeholder = FeedPlaceholder,

--- a/src/context/Feed.tsx
+++ b/src/context/Feed.tsx
@@ -164,7 +164,7 @@ export function Feed<
       sharedFeedManagers[feedId] ||
       new FeedManager<UT, AT, CT, RT, CRT, PT>({ ...props, analyticsClient, client, user, errorHandler })
     );
-  }, [feedGroup]);
+  }, [feedGroup, userId]);
 
   useEffect(() => {
     const forceUpdate = () => setForceUpdateState((prevState) => prevState + 1);

--- a/src/context/FeedManager.tsx
+++ b/src/context/FeedManager.tsx
@@ -1023,13 +1023,14 @@ export class FeedManager<
     }
   };
 
-  unsubscribe = () => {
+  unsubscribe = async () => {
     const { subscription } = this.state;
     if (!subscription || this.registeredCallbacks.length) {
       return;
     }
 
     try {
+      await subscription;
       // @ts-expect-error
       subscription?.cancel();
       console.log(`stopped listening to changes in realtime for ${this.feed().id}`);

--- a/src/context/FeedManager.tsx
+++ b/src/context/FeedManager.tsx
@@ -167,10 +167,10 @@ export class FeedManager<
       | Partial<FeedManagerState<UT, AT, CT, RT, CRT>>
       | ((oldState: FeedManagerState<UT, AT, CT, RT, CRT>) => Partial<FeedManagerState<UT, AT, CT, RT, CRT>>),
   ) => {
-    if (typeof changed === 'function') {
-      changed = changed(this.state);
-    }
-    this.state = { ...this.state, ...changed };
+    this.state = {
+      ...this.state,
+      ...(typeof changed === 'function' ? changed(this.state) : changed),
+    };
     this.triggerUpdate();
   };
 
@@ -1023,14 +1023,15 @@ export class FeedManager<
     }
   };
 
-  unsubscribe = async () => {
+  unsubscribe = () => {
     const { subscription } = this.state;
     if (!subscription || this.registeredCallbacks.length) {
       return;
     }
 
     try {
-      (await subscription).cancel();
+      // @ts-expect-error
+      subscription?.cancel();
       console.log(`stopped listening to changes in realtime for ${this.feed().id}`);
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
This PR addresses the issue #285 and partially #263 where after changing `feedGroup` or `userId` the appropriate subscription to real-time data wouldn't get properly canceled.