### PR TITLE
Add `className` and `style` properties to wrappers of UI components

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@types/url-parse": "^1.4.3",
     "@types/webscopeio__react-textarea-autocomplete": "^4.7.0",
     "@webscopeio/react-textarea-autocomplete": "^4.7.3",
+    "classnames": "^2.3.1",
     "dayjs": "^1.10.4",
     "emoji-mart": "^3.0.1",
     "getstream": "^7.2.11",

--- a/src/components/Activity.tsx
+++ b/src/components/Activity.tsx
@@ -102,9 +102,9 @@ export const Activity = <
   userId,
   feedGroup,
   className = 'raf-activity',
-  ...rest
+  style,
 }: ActivityProps<UT, AT, CT, RT, CRT>) => (
-  <div className={className} {...rest}>
+  <div className={className} style={style}>
     {smartRender<ActivityHeaderProps<UT, AT>>(Header, { HeaderRight, icon, activity, onClickUser })}
     {smartRender<ActivityContentProps<UT, AT, CT, RT, CRT>>(Content, {
       activity,

--- a/src/components/Activity.tsx
+++ b/src/components/Activity.tsx
@@ -6,7 +6,12 @@ import { ActivityHeader as DefaultActivityHeader, ActivityHeaderProps } from './
 import { Card as DefaultCard, CardProps } from './Card';
 import { ActivityFooterProps } from './ActivityFooter';
 
-import { smartRender, ElementOrComponentOrLiteralType, UserOrDefaultReturnType } from '../utils';
+import {
+  smartRender,
+  ElementOrComponentOrLiteralType,
+  UserOrDefaultReturnType,
+  PropsWithElementAttributes,
+} from '../utils';
 import { DefaultAT, DefaultUT } from '../context/StreamApp';
 
 type WordClickHandler = (word: string) => void;
@@ -17,7 +22,7 @@ export type ActivityProps<
   CT extends UR = UR,
   RT extends UR = UR,
   CRT extends UR = UR
-> = {
+> = PropsWithElementAttributes<{
   /** The activity received for stream for which to show the like button. This is
    * used to initialize the toggle state and the counter. */
   activity: EnrichedActivity<UT, AT, CT, RT, CRT>;
@@ -52,7 +57,7 @@ export type ActivityProps<
   /** The user_id part of the feed that the activity should be reposted to when
    * pressing the RepostButton */
   userId?: string;
-};
+}>;
 
 const DefaultRepost = <
   UT extends DefaultUT = DefaultUT,
@@ -96,8 +101,10 @@ export const Activity = <
   Repost = DefaultRepost,
   userId,
   feedGroup,
+  className = 'raf-activity',
+  ...rest
 }: ActivityProps<UT, AT, CT, RT, CRT>) => (
-  <div className="raf-activity">
+  <div className={className} {...rest}>
     {smartRender<ActivityHeaderProps<UT, AT>>(Header, { HeaderRight, icon, activity, onClickUser })}
     {smartRender<ActivityContentProps<UT, AT, CT, RT, CRT>>(Content, {
       activity,

--- a/src/components/Activity.tsx
+++ b/src/components/Activity.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { EnrichedActivity, UR } from 'getstream';
 
 import { ActivityContent as DefaultActivityContent, ActivityContentProps } from './ActivityContent';
@@ -101,10 +102,10 @@ export const Activity = <
   Repost = DefaultRepost,
   userId,
   feedGroup,
-  className = 'raf-activity',
+  className,
   style,
 }: ActivityProps<UT, AT, CT, RT, CRT>) => (
-  <div className={className} style={style}>
+  <div className={classNames('raf-activity', className)} style={style}>
     {smartRender<ActivityHeaderProps<UT, AT>>(Header, { HeaderRight, icon, activity, onClickUser })}
     {smartRender<ActivityContentProps<UT, AT, CT, RT, CRT>>(Content, {
       activity,

--- a/src/components/ActivityContent.tsx
+++ b/src/components/ActivityContent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { FileIcon } from 'react-file-utils';
 import { EnrichedActivity, UR } from 'getstream';
 
@@ -28,7 +29,7 @@ export const ActivityContent = <
   activity,
   Repost,
   Card = DefaultCard,
-  className = 'raf-activity__content',
+  className,
   style,
   ...props
 }: ActivityContentProps<UT, AT, CT, RT, CRT>) => {
@@ -41,7 +42,7 @@ export const ActivityContent = <
   } = activity;
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-activity__content', className)} style={style}>
       {text && (
         <div style={{ padding: '8px 16px' }}>
           <p>{textRenderer(text, 'raf-activity', props.onClickMention, props.onClickHashtag)}</p>

--- a/src/components/ActivityContent.tsx
+++ b/src/components/ActivityContent.tsx
@@ -28,6 +28,8 @@ export const ActivityContent = <
   activity,
   Repost,
   Card = DefaultCard,
+  className = 'raf-activity__content',
+  style,
   ...props
 }: ActivityContentProps<UT, AT, CT, RT, CRT>) => {
   const {
@@ -39,7 +41,7 @@ export const ActivityContent = <
   } = activity;
 
   return (
-    <div className="raf-activity__content">
+    <div className={className} style={style}>
       {text && (
         <div style={{ padding: '8px 16px' }}>
           <p>{textRenderer(text, 'raf-activity', props.onClickMention, props.onClickHashtag)}</p>

--- a/src/components/ActivityFooter.tsx
+++ b/src/components/ActivityFooter.tsx
@@ -6,6 +6,7 @@ import { RepostButton } from './RepostButton';
 import { Flex } from './Flex';
 import { DefaultAT, DefaultUT } from '../context/StreamApp';
 import { ActivityProps } from './Activity';
+import { PropsWithElementAttributes } from '../utils';
 
 export type ActivityFooterProps<
   UT extends DefaultUT = DefaultUT,
@@ -13,7 +14,9 @@ export type ActivityFooterProps<
   CT extends UR = UR,
   RT extends UR = UR,
   CRT extends UR = UR
-> = Pick<ActivityProps<UT, AT, CT, RT, CRT>, 'activity' | 'feedGroup' | 'userId'> & { targetFeeds?: string[] };
+> = PropsWithElementAttributes<
+  Pick<ActivityProps<UT, AT, CT, RT, CRT>, 'activity' | 'feedGroup' | 'userId'> & { targetFeeds?: string[] }
+>;
 
 export const ActivityFooter = <
   UT extends DefaultUT = DefaultUT,
@@ -21,15 +24,20 @@ export const ActivityFooter = <
   CT extends UR = UR,
   RT extends UR = UR,
   CRT extends UR = UR
->(
-  props: ActivityFooterProps<UT, AT, CT, RT, CRT>,
-) => (
-  <div className="raf-activity-footer">
+>({
+  activity,
+  feedGroup = 'user',
+  userId,
+  targetFeeds,
+  className = 'raf-activity-footer',
+  ...rest
+}: ActivityFooterProps<UT, AT, CT, RT, CRT>) => (
+  <div className={className} {...rest}>
     <div className="raf-activity-footer__left" />
     <div className="raf-activity-footer__right">
       <Flex a="center">
-        <LikeButton<UT, AT, CT, RT, CRT> {...props} />
-        <RepostButton<UT, AT, CT, RT, CRT> {...props} />
+        <LikeButton<UT, AT, CT, RT, CRT> {...{ activity, targetFeeds, feedGroup, userId }} />
+        <RepostButton<UT, AT, CT, RT, CRT> {...{ activity, targetFeeds, feedGroup, userId }} />
       </Flex>
     </div>
   </div>

--- a/src/components/ActivityFooter.tsx
+++ b/src/components/ActivityFooter.tsx
@@ -6,7 +6,6 @@ import { RepostButton } from './RepostButton';
 import { Flex } from './Flex';
 import { DefaultAT, DefaultUT } from '../context/StreamApp';
 import { ActivityProps } from './Activity';
-import { PropsWithElementAttributes } from '../utils';
 
 export type ActivityFooterProps<
   UT extends DefaultUT = DefaultUT,
@@ -14,9 +13,9 @@ export type ActivityFooterProps<
   CT extends UR = UR,
   RT extends UR = UR,
   CRT extends UR = UR
-> = PropsWithElementAttributes<
-  Pick<ActivityProps<UT, AT, CT, RT, CRT>, 'activity' | 'feedGroup' | 'userId'> & { targetFeeds?: string[] }
->;
+> = Pick<ActivityProps<UT, AT, CT, RT, CRT>, 'activity' | 'feedGroup' | 'userId' | 'className' | 'style'> & {
+  targetFeeds?: string[];
+};
 
 export const ActivityFooter = <
   UT extends DefaultUT = DefaultUT,
@@ -30,9 +29,9 @@ export const ActivityFooter = <
   userId,
   targetFeeds,
   className = 'raf-activity-footer',
-  ...rest
+  style,
 }: ActivityFooterProps<UT, AT, CT, RT, CRT>) => (
-  <div className={className} {...rest}>
+  <div className={className} style={style}>
     <div className="raf-activity-footer__left" />
     <div className="raf-activity-footer__right">
       <Flex a="center">
@@ -42,7 +41,3 @@ export const ActivityFooter = <
     </div>
   </div>
 );
-
-ActivityFooter.defaultProps = {
-  feedGroup: 'user',
-};

--- a/src/components/ActivityFooter.tsx
+++ b/src/components/ActivityFooter.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { UR } from 'getstream';
 
 import { LikeButton } from './LikeButton';
@@ -28,10 +29,10 @@ export const ActivityFooter = <
   feedGroup = 'user',
   userId,
   targetFeeds,
-  className = 'raf-activity-footer',
+  className,
   style,
 }: ActivityFooterProps<UT, AT, CT, RT, CRT>) => (
-  <div className={className} style={style}>
+  <div className={classNames('raf-activity-footer', className)} style={style}>
     <div className="raf-activity-footer__left" />
     <div className="raf-activity-footer__right">
       <Flex a="center">

--- a/src/components/ActivityFooter.tsx
+++ b/src/components/ActivityFooter.tsx
@@ -36,8 +36,13 @@ export const ActivityFooter = <
     <div className="raf-activity-footer__left" />
     <div className="raf-activity-footer__right">
       <Flex a="center">
-        <LikeButton<UT, AT, CT, RT, CRT> {...{ activity, targetFeeds, feedGroup, userId }} />
-        <RepostButton<UT, AT, CT, RT, CRT> {...{ activity, targetFeeds, feedGroup, userId }} />
+        <LikeButton<UT, AT, CT, RT, CRT> activity={activity} targetFeeds={targetFeeds} />
+        <RepostButton<UT, AT, CT, RT, CRT>
+          activity={activity}
+          targetFeeds={targetFeeds}
+          feedGroup={feedGroup}
+          userId={userId}
+        />
       </Flex>
     </div>
   </div>

--- a/src/components/ActivityHeader.tsx
+++ b/src/components/ActivityHeader.tsx
@@ -8,7 +8,7 @@ import { UserBar } from './UserBar';
 
 export type ActivityHeaderProps<UT extends DefaultUT = DefaultUT, AT extends DefaultAT = DefaultAT> = Pick<
   ActivityProps<UT, AT>,
-  'activity' | 'HeaderRight' | 'icon' | 'onClickUser'
+  'activity' | 'HeaderRight' | 'icon' | 'onClickUser' | 'className' | 'style'
 >;
 
 export const ActivityHeader = <UT extends DefaultUT = DefaultUT, AT extends DefaultAT = DefaultAT>({
@@ -16,6 +16,8 @@ export const ActivityHeader = <UT extends DefaultUT = DefaultUT, AT extends Defa
   HeaderRight,
   icon,
   onClickUser,
+  style = { padding: '8px 16px' },
+  ...rest
 }: ActivityHeaderProps<UT, AT>) => {
   const { tDateTimeParser } = useTranslationContext();
 
@@ -23,7 +25,7 @@ export const ActivityHeader = <UT extends DefaultUT = DefaultUT, AT extends Defa
   const handleUserClick = useOnClickUser<UT>(onClickUser);
 
   return (
-    <div style={{ padding: '8px 16px' }}>
+    <div style={style} {...rest}>
       <UserBar
         username={actor.data.name}
         avatar={actor.data.profileImage}

--- a/src/components/ActivityHeader.tsx
+++ b/src/components/ActivityHeader.tsx
@@ -17,7 +17,7 @@ export const ActivityHeader = <UT extends DefaultUT = DefaultUT, AT extends Defa
   icon,
   onClickUser,
   style = { padding: '8px 16px' },
-  ...rest
+  className,
 }: ActivityHeaderProps<UT, AT>) => {
   const { tDateTimeParser } = useTranslationContext();
 
@@ -25,7 +25,7 @@ export const ActivityHeader = <UT extends DefaultUT = DefaultUT, AT extends Defa
   const handleUserClick = useOnClickUser<UT>(onClickUser);
 
   return (
-    <div style={style} {...rest}>
+    <div style={style} className={className}>
       <UserBar
         username={actor.data.name}
         avatar={actor.data.profileImage}

--- a/src/components/AttachedActivity.tsx
+++ b/src/components/AttachedActivity.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import classNames from 'classnames';
 import { EnrichedActivity } from 'getstream';
 import { Thumbnail } from 'react-file-utils';
 
@@ -14,7 +15,7 @@ export type AttachedActivityProps<
 
 export function AttachedActivity<UT extends DefaultUT = DefaultUT, AT extends DefaultAT = DefaultAT>({
   activity: { object, verb, attachments, actor },
-  className = 'raf-attached-activity',
+  className,
   style,
 }: AttachedActivityProps<UT, AT>) {
   const images = attachments?.images ?? [];
@@ -23,7 +24,7 @@ export function AttachedActivity<UT extends DefaultUT = DefaultUT, AT extends De
   if (verb !== 'repost' && verb !== 'post' && verb !== 'comment') return null;
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-attached-activity', className)} style={style}>
       {images.length ? (
         <div className="raf-attached-activity__images">
           {images.slice(0, 5).map((image, i) => (

--- a/src/components/AttachedActivity.tsx
+++ b/src/components/AttachedActivity.tsx
@@ -2,15 +2,20 @@ import React, { useMemo } from 'react';
 import { EnrichedActivity } from 'getstream';
 import { Thumbnail } from 'react-file-utils';
 
-import { userOrDefault } from '../utils';
+import { userOrDefault, PropsWithElementAttributes } from '../utils';
 import { DefaultUT, DefaultAT } from '../context/StreamApp';
 
-export type AttachedActivityProps<UT extends DefaultUT = DefaultUT, AT extends DefaultAT = DefaultAT> = {
+export type AttachedActivityProps<
+  UT extends DefaultUT = DefaultUT,
+  AT extends DefaultAT = DefaultAT
+> = PropsWithElementAttributes<{
   activity: EnrichedActivity<UT, AT>;
-};
+}>;
 
 export function AttachedActivity<UT extends DefaultUT = DefaultUT, AT extends DefaultAT = DefaultAT>({
   activity: { object, verb, attachments, actor },
+  className = 'raf-attached-activity',
+  ...rest
 }: AttachedActivityProps<UT, AT>) {
   const images = attachments?.images ?? [];
   const user = useMemo(() => userOrDefault<UT>(actor), [actor]);
@@ -18,7 +23,7 @@ export function AttachedActivity<UT extends DefaultUT = DefaultUT, AT extends De
   if (verb !== 'repost' && verb !== 'post' && verb !== 'comment') return null;
 
   return (
-    <div className="raf-attached-activity">
+    <div className={className} {...rest}>
       {images.length ? (
         <div className="raf-attached-activity__images">
           {images.slice(0, 5).map((image, i) => (

--- a/src/components/AttachedActivity.tsx
+++ b/src/components/AttachedActivity.tsx
@@ -15,7 +15,7 @@ export type AttachedActivityProps<
 export function AttachedActivity<UT extends DefaultUT = DefaultUT, AT extends DefaultAT = DefaultAT>({
   activity: { object, verb, attachments, actor },
   className = 'raf-attached-activity',
-  ...rest
+  style,
 }: AttachedActivityProps<UT, AT>) {
   const images = attachments?.images ?? [];
   const user = useMemo(() => userOrDefault<UT>(actor), [actor]);
@@ -23,7 +23,7 @@ export function AttachedActivity<UT extends DefaultUT = DefaultUT, AT extends De
   if (verb !== 'repost' && verb !== 'post' && verb !== 'comment') return null;
 
   return (
-    <div className={className} {...rest}>
+    <div className={className} style={style}>
       {images.length ? (
         <div className="raf-attached-activity__images">
           {images.slice(0, 5).map((image, i) => (

--- a/src/components/Audio.tsx
+++ b/src/components/Audio.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect, MouseEventHandler } from 'react';
+import classNames from 'classnames';
 import { IconButton } from 'react-file-utils';
 import { OGAPIResponse } from 'getstream';
 
@@ -13,7 +14,7 @@ type AudioProps = PropsWithElementAttributes<{
 export const Audio = ({
   og: { audios = [], images = [], description, title },
   handleClose,
-  className = 'raf-audio',
+  className,
   style,
 }: AudioProps) => {
   const audioReference = useRef<HTMLAudioElement | null>(null);
@@ -65,7 +66,7 @@ export const Audio = ({
   const [{ image: imageURL }] = images;
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-audio', className)} style={style}>
       <div className="raf-audio__wrapper">
         <audio ref={audioReference}>
           <source src={audioURL} type="audio/mp3" />

--- a/src/components/Audio.tsx
+++ b/src/components/Audio.tsx
@@ -14,7 +14,7 @@ export const Audio = ({
   og: { audios = [], images = [], description, title },
   handleClose,
   className = 'raf-audio',
-  ...rest
+  style,
 }: AudioProps) => {
   const audioReference = useRef<HTMLAudioElement | null>(null);
   const intervalReference = useRef<number>();
@@ -65,7 +65,7 @@ export const Audio = ({
   const [{ image: imageURL }] = images;
 
   return (
-    <div className={className} {...rest}>
+    <div className={className} style={style}>
       <div className="raf-audio__wrapper">
         <audio ref={audioReference}>
           <source src={audioURL} type="audio/mp3" />

--- a/src/components/Audio.tsx
+++ b/src/components/Audio.tsx
@@ -2,15 +2,20 @@ import React, { useRef, useState, useEffect, MouseEventHandler } from 'react';
 import { IconButton } from 'react-file-utils';
 import { OGAPIResponse } from 'getstream';
 
-import { sanitizeURL, smartRender } from '../utils';
+import { sanitizeURL, smartRender, PropsWithElementAttributes } from '../utils';
 import { CloseIcon, PlayCircleIcon, PauseCircleIcon } from './Icons';
 
-type AudioProps = {
+type AudioProps = PropsWithElementAttributes<{
   og: OGAPIResponse;
   handleClose?: (event: React.SyntheticEvent) => void;
-};
+}>;
 
-export const Audio = ({ og: { audios = [], images = [], description, title }, handleClose }: AudioProps) => {
+export const Audio = ({
+  og: { audios = [], images = [], description, title },
+  handleClose,
+  className = 'raf-audio',
+  ...rest
+}: AudioProps) => {
   const audioReference = useRef<HTMLAudioElement | null>(null);
   const intervalReference = useRef<number>();
 
@@ -60,7 +65,7 @@ export const Audio = ({ og: { audios = [], images = [], description, title }, ha
   const [{ image: imageURL }] = images;
 
   return (
-    <div className="raf-audio">
+    <div className={className} {...rest}>
       <div className="raf-audio__wrapper">
         <audio ref={audioReference}>
           <source src={audioURL} type="audio/mp3" />

--- a/src/components/Avatar.test.tsx
+++ b/src/components/Avatar.test.tsx
@@ -9,9 +9,8 @@ describe('Avatar', () => {
     const tree = renderer.create(<Avatar />).toJSON();
     expect(tree).toMatchInlineSnapshot(`
       <svg
-        className="raf-avatar  "
+        className="raf-avatar"
         enableBackground="new 312.809 0 401 401"
-        style={Object {}}
         version="1.1"
         viewBox="312.809 0 401 401"
         xmlSpace="preserve"

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,14 +1,15 @@
 import React, { MouseEventHandler as F } from 'react';
 import { AvatarIcon } from './Icons';
+import { PropsWithElementAttributes } from '../utils';
 
-export type AvatarProps<T extends SVGSVGElement | HTMLImageElement> = {
+export type AvatarProps<T extends SVGSVGElement | HTMLImageElement> = PropsWithElementAttributes<{
   alt?: string;
   circle?: boolean;
   image?: T extends HTMLImageElement ? string : never;
   onClick?: F<T>;
   rounded?: boolean;
   size?: number;
-};
+}>;
 
 export function Avatar<T extends HTMLImageElement | SVGSVGElement>({
   size,
@@ -17,15 +18,12 @@ export function Avatar<T extends HTMLImageElement | SVGSVGElement>({
   rounded,
   circle,
   onClick,
+  className = `raf-avatar${rounded ? ' raf-avatar--rounded' : ''}${circle ? ' raf-avatar--circle' : ''}`,
+  style = size ? { width: `${size}px`, height: `${size}px` } : undefined,
 }: AvatarProps<T>) {
-  const sharedProperties = {
-    style: size ? { width: `${size}px`, height: `${size}px` } : {},
-    className: `raf-avatar ${rounded ? 'raf-avatar--rounded' : ''} ${circle ? 'raf-avatar--circle' : ''}`,
-  };
-
   return image ? (
-    <img {...sharedProperties} src={image} alt={alt ?? ''} onClick={onClick as F<HTMLImageElement>} />
+    <img className={className} style={style} src={image} alt={alt ?? ''} onClick={onClick as F<HTMLImageElement>} />
   ) : (
-    <AvatarIcon {...sharedProperties} onClick={onClick as F<SVGSVGElement>} />
+    <AvatarIcon className={className} style={style} onClick={onClick as F<SVGSVGElement>} />
   );
 }

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEventHandler as F } from 'react';
+import classNames from 'classnames';
 import { AvatarIcon } from './Icons';
 import { PropsWithElementAttributes } from '../utils';
 
@@ -18,12 +19,17 @@ export function Avatar<T extends HTMLImageElement | SVGSVGElement>({
   rounded,
   circle,
   onClick,
-  className = `raf-avatar${rounded ? ' raf-avatar--rounded' : ''}${circle ? ' raf-avatar--circle' : ''}`,
+  className,
   style = size ? { width: `${size}px`, height: `${size}px` } : undefined,
 }: AvatarProps<T>) {
+  const cn = classNames('raf-avatar', className, {
+    'raf-avatar--rounded': rounded,
+    'raf-avatar--circle': circle,
+  });
+
   return image ? (
-    <img className={className} style={style} src={image} alt={alt ?? ''} onClick={onClick as F<HTMLImageElement>} />
+    <img className={cn} style={style} src={image} alt={alt ?? ''} onClick={onClick as F<HTMLImageElement>} />
   ) : (
-    <AvatarIcon className={className} style={style} onClick={onClick as F<SVGSVGElement>} />
+    <AvatarIcon className={cn} style={style} onClick={onClick as F<SVGSVGElement>} />
   );
 }

--- a/src/components/AvatarGroup.test.tsx
+++ b/src/components/AvatarGroup.test.tsx
@@ -48,7 +48,7 @@ describe('AvatarGroup', () => {
         >
           <img
             alt=""
-            className="raf-avatar  raf-avatar--circle"
+            className="raf-avatar raf-avatar--circle"
             src="https://randomuser.me/api/portraits/men/1.jpg"
             style={
               Object {
@@ -63,7 +63,7 @@ describe('AvatarGroup', () => {
         >
           <img
             alt=""
-            className="raf-avatar  raf-avatar--circle"
+            className="raf-avatar raf-avatar--circle"
             src="https://randomuser.me/api/portraits/women/1.jpg"
             style={
               Object {
@@ -78,7 +78,7 @@ describe('AvatarGroup', () => {
         >
           <img
             alt=""
-            className="raf-avatar  raf-avatar--circle"
+            className="raf-avatar raf-avatar--circle"
             src="https://randomuser.me/api/portraits/men/3.jpg"
             style={
               Object {
@@ -105,7 +105,7 @@ describe('AvatarGroup', () => {
         >
           <img
             alt=""
-            className="raf-avatar  raf-avatar--circle"
+            className="raf-avatar raf-avatar--circle"
             onClick={[Function]}
             src="https://randomuser.me/api/portraits/men/1.jpg"
             style={
@@ -121,7 +121,7 @@ describe('AvatarGroup', () => {
         >
           <img
             alt=""
-            className="raf-avatar  raf-avatar--circle"
+            className="raf-avatar raf-avatar--circle"
             onClick={[Function]}
             src="https://randomuser.me/api/portraits/women/1.jpg"
             style={

--- a/src/components/AvatarGroup.tsx
+++ b/src/components/AvatarGroup.tsx
@@ -18,12 +18,12 @@ export function AvatarGroup<UT extends DefaultUT = DefaultUT>({
   avatarSize = 30,
   onClickUser,
   className = 'raf-avatar-group',
-  ...rest
+  style,
 }: AvatarGroupProps<UT>) {
   const handleUserClick = useOnClickUser<UT>(onClickUser);
 
   return (
-    <div className={className} {...rest}>
+    <div className={className} style={style}>
       {users.slice(0, limit).map((user, i) => (
         <div className="raf-avatar-group__avatar" key={`avatar-${i}`}>
           <Avatar onClick={handleUserClick?.(user)} image={user.data?.profileImage} size={avatarSize} circle />

--- a/src/components/AvatarGroup.tsx
+++ b/src/components/AvatarGroup.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { EnrichedUser } from 'getstream';
 
 import { useOnClickUser, OnClickUserHandler, PropsWithElementAttributes } from '../utils';
@@ -17,13 +18,13 @@ export function AvatarGroup<UT extends DefaultUT = DefaultUT>({
   users = [],
   avatarSize = 30,
   onClickUser,
-  className = 'raf-avatar-group',
+  className,
   style,
 }: AvatarGroupProps<UT>) {
   const handleUserClick = useOnClickUser<UT>(onClickUser);
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-avatar-group', className)} style={style}>
       {users.slice(0, limit).map((user, i) => (
         <div className="raf-avatar-group__avatar" key={`avatar-${i}`}>
           <Avatar onClick={handleUserClick?.(user)} image={user.data?.profileImage} size={avatarSize} circle />

--- a/src/components/AvatarGroup.tsx
+++ b/src/components/AvatarGroup.tsx
@@ -1,27 +1,29 @@
 import React from 'react';
 import { EnrichedUser } from 'getstream';
 
-import { useOnClickUser, OnClickUserHandler } from '../utils';
+import { useOnClickUser, OnClickUserHandler, PropsWithElementAttributes } from '../utils';
 import { DefaultUT } from '../context/StreamApp';
 import { Avatar } from './Avatar';
 
-export type AvatarGroupProps<UT extends DefaultUT = DefaultUT> = {
+export type AvatarGroupProps<UT extends DefaultUT = DefaultUT> = PropsWithElementAttributes<{
   avatarSize?: number;
   limit?: number;
   onClickUser?: OnClickUserHandler<UT>;
   users?: Array<EnrichedUser<UT>>;
-};
+}>;
 
 export function AvatarGroup<UT extends DefaultUT = DefaultUT>({
   limit = 5,
   users = [],
   avatarSize = 30,
   onClickUser,
+  className = 'raf-avatar-group',
+  ...rest
 }: AvatarGroupProps<UT>) {
   const handleUserClick = useOnClickUser<UT>(onClickUser);
 
   return (
-    <div className="raf-avatar-group">
+    <div className={className} {...rest}>
       {users.slice(0, limit).map((user, i) => (
         <div className="raf-avatar-group__avatar" key={`avatar-${i}`}>
           <Avatar onClick={handleUserClick?.(user)} image={user.data?.profileImage} size={avatarSize} circle />

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,5 @@
 import React, { ButtonHTMLAttributes, MouseEvent, KeyboardEvent, PropsWithChildren } from 'react';
+import classNames from 'classnames';
 import { LoadingIndicator } from 'react-file-utils';
 
 import { PropsWithElementAttributes } from '../utils';
@@ -22,10 +23,17 @@ export const Button = ({
   onClick,
   onKeyPress,
   children,
-  className = `raf-button raf-button--${buttonStyle}`,
+  className,
   style,
 }: ButtonProps) => (
-  <button className={className} onClick={onClick} onKeyPress={onKeyPress} type={type} disabled={disabled} style={style}>
+  <button
+    className={classNames('raf-button', `raf-button--${buttonStyle}`, className)}
+    onClick={onClick}
+    onKeyPress={onKeyPress}
+    type={type}
+    disabled={disabled}
+    style={style}
+  >
     {loading ? <LoadingIndicator backgroundColor="rgba(255,255,255,0.1)" color="rgba(255,255,255,0.4)" /> : children}
   </button>
 );

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -23,9 +23,9 @@ export const Button = ({
   onKeyPress,
   children,
   className = `raf-button raf-button--${buttonStyle}`,
-  ...rest
+  style,
 }: ButtonProps) => (
-  <button className={className} onClick={onClick} onKeyPress={onKeyPress} type={type} disabled={disabled} {...rest}>
+  <button className={className} onClick={onClick} onKeyPress={onKeyPress} type={type} disabled={disabled} style={style}>
     {loading ? <LoadingIndicator backgroundColor="rgba(255,255,255,0.1)" color="rgba(255,255,255,0.4)" /> : children}
   </button>
 );

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,15 +1,18 @@
-import React, { ButtonHTMLAttributes, MouseEvent, KeyboardEvent, ReactNode } from 'react';
+import React, { ButtonHTMLAttributes, MouseEvent, KeyboardEvent, PropsWithChildren } from 'react';
 import { LoadingIndicator } from 'react-file-utils';
 
-export type ButtonProps = {
-  buttonStyle?: 'info' | 'primary' | 'faded';
-  children?: ReactNode;
-  disabled?: boolean;
-  loading?: boolean;
-  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
-  onKeyPress?: (event: KeyboardEvent<HTMLButtonElement>) => void;
-  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
-};
+import { PropsWithElementAttributes } from '../utils';
+
+export type ButtonProps = PropsWithChildren<
+  PropsWithElementAttributes<{
+    buttonStyle?: 'info' | 'primary' | 'faded';
+    disabled?: boolean;
+    loading?: boolean;
+    onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+    onKeyPress?: (event: KeyboardEvent<HTMLButtonElement>) => void;
+    type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
+  }>
+>;
 
 export const Button = ({
   buttonStyle = 'info',
@@ -19,14 +22,10 @@ export const Button = ({
   onClick,
   onKeyPress,
   children,
+  className = `raf-button raf-button--${buttonStyle}`,
+  ...rest
 }: ButtonProps) => (
-  <button
-    className={`raf-button${buttonStyle ? ' raf-button--' + buttonStyle : ''}`}
-    onClick={onClick}
-    onKeyPress={onKeyPress}
-    type={type}
-    disabled={disabled}
-  >
+  <button className={className} onClick={onClick} onKeyPress={onKeyPress} type={type} disabled={disabled} {...rest}>
     {loading ? <LoadingIndicator backgroundColor="rgba(255,255,255,0.1)" color="rgba(255,255,255,0.4)" /> : children}
   </button>
 );

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -25,7 +25,7 @@ export const Card = ({
   url,
   title,
   className,
-  ...rest
+  style,
 }: CardProps) => {
   const sanitizedURL = useMemo(() => sanitizeURL(url), [url]);
   const trimmedURL = useMemo(() => trimURL(sanitizedURL), [sanitizedURL]);
@@ -38,7 +38,7 @@ export const Card = ({
       target="blank"
       rel="nofollow noreferrer noopener"
       className={className ?? `raf-card ${image !== undefined ? 'raf-card--with-image' : ''}`}
-      {...rest}
+      style={style}
     >
       {handleClose && image ? (
         <IconButton onClick={handleClose}>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -2,15 +2,18 @@ import React, { SyntheticEvent, useMemo } from 'react';
 import { IconButton } from 'react-file-utils';
 import { OGAPIResponse } from 'getstream';
 
-import { sanitizeURL, trimURL } from '../utils';
+import { sanitizeURL, trimURL, PropsWithElementAttributes } from '../utils';
 import { AvatarIcon, CloseIcon } from './Icons';
 
-export type CardProps = {
-  alt?: string;
-  handleClose?: (e: SyntheticEvent) => void;
-  image?: string | null;
-  nolink?: boolean;
-} & Pick<OGAPIResponse, 'description' | 'images' | 'url' | 'title'>;
+export type CardProps = PropsWithElementAttributes<
+  {
+    alt?: string;
+    handleClose?: (e: SyntheticEvent) => void;
+    image?: string | null;
+    nolink?: boolean;
+  } & Pick<OGAPIResponse, 'description' | 'images' | 'url' | 'title'>,
+  HTMLAnchorElement
+>;
 
 export const Card = ({
   alt,
@@ -21,6 +24,8 @@ export const Card = ({
   nolink,
   url,
   title,
+  className,
+  ...rest
 }: CardProps) => {
   const sanitizedURL = useMemo(() => sanitizeURL(url), [url]);
   const trimmedURL = useMemo(() => trimURL(sanitizedURL), [sanitizedURL]);
@@ -32,7 +37,8 @@ export const Card = ({
       href={nolink ? undefined : sanitizedURL}
       target="blank"
       rel="nofollow noreferrer noopener"
-      className={`raf-card ${image !== undefined ? 'raf-card--with-image' : ''}`}
+      className={className ?? `raf-card ${image !== undefined ? 'raf-card--with-image' : ''}`}
+      {...rest}
     >
       {handleClose && image ? (
         <IconButton onClick={handleClose}>

--- a/src/components/CommentField.test.tsx
+++ b/src/components/CommentField.test.tsx
@@ -61,7 +61,7 @@ describe('CommentField', () => {
       >
         <img
           alt=""
-          className="raf-avatar  raf-avatar--circle"
+          className="raf-avatar raf-avatar--circle"
           src="https://getstream.imgix.net/images/random_svg/A.png"
           style={
             Object {

--- a/src/components/CommentField.tsx
+++ b/src/components/CommentField.tsx
@@ -38,7 +38,7 @@ export const CommentField = <UT extends DefaultUT = DefaultUT, AT extends Defaul
   trigger,
   targetFeeds,
   className = 'raf-comment-field',
-  ...rest
+  style,
 }: CommentFieldProps<UT, AT>) => {
   const feed = useFeedContext<UT, AT>();
   const { t } = useTranslationContext();
@@ -76,7 +76,7 @@ export const CommentField = <UT extends DefaultUT = DefaultUT, AT extends Defaul
   }, []);
 
   return (
-    <form onSubmit={handleFormSubmit} className={className} {...rest}>
+    <form onSubmit={handleFormSubmit} className={className} style={style}>
       {image && <Avatar image={image} circle size={39} />}
       <div className="raf-comment-field__group">
         <Textarea

--- a/src/components/CommentField.tsx
+++ b/src/components/CommentField.tsx
@@ -5,24 +5,29 @@ import { Data as EmojiDataSet } from 'emoji-mart';
 import { Avatar } from './Avatar';
 import { Button } from './Button';
 import { Textarea, TextareaProps } from './Textarea';
-import { inputValueFromEvent } from '../utils';
+import { inputValueFromEvent, PropsWithElementAttributes } from '../utils';
 import { useFeedContext, useTranslationContext } from '../context';
 import { DefaultAT, DefaultUT } from '../context/StreamApp';
 
-export type CommentFieldProps<UT extends DefaultUT = DefaultUT, AT extends DefaultAT = DefaultAT> = {
-  activity: EnrichedActivity<UT, AT>;
-  /** Override the default emoji dataset, library has a light set of emojis
-   * to show more emojis use your own or emoji-mart sets
-   * https://github.com/missive/emoji-mart#datasets
-   */
-  emojiData?: EmojiDataSet;
-  image?: string;
-  kind?: string;
-  onSuccess?: () => void;
-  placeholder?: string;
-  targetFeeds?: string[];
-  trigger?: TextareaProps['trigger'];
-};
+export type CommentFieldProps<
+  UT extends DefaultUT = DefaultUT,
+  AT extends DefaultAT = DefaultAT
+> = PropsWithElementAttributes<
+  {
+    activity: EnrichedActivity<UT, AT>;
+    /** Override the default emoji dataset, library has a light set of emojis
+     * to show more emojis use your own or emoji-mart sets
+     * https://github.com/missive/emoji-mart#datasets
+     */
+    emojiData?: EmojiDataSet;
+    image?: string;
+    onSuccess?: () => void;
+    placeholder?: string;
+    targetFeeds?: string[];
+    trigger?: TextareaProps['trigger'];
+  },
+  HTMLFormElement
+>;
 
 export const CommentField = <UT extends DefaultUT = DefaultUT, AT extends DefaultAT = DefaultAT>({
   activity,
@@ -32,6 +37,8 @@ export const CommentField = <UT extends DefaultUT = DefaultUT, AT extends Defaul
   placeholder,
   trigger,
   targetFeeds,
+  className = 'raf-comment-field',
+  ...rest
 }: CommentFieldProps<UT, AT>) => {
   const feed = useFeedContext<UT, AT>();
   const { t } = useTranslationContext();
@@ -69,7 +76,7 @@ export const CommentField = <UT extends DefaultUT = DefaultUT, AT extends Defaul
   }, []);
 
   return (
-    <form onSubmit={handleFormSubmit} className="raf-comment-field">
+    <form onSubmit={handleFormSubmit} className={className} {...rest}>
       {image && <Avatar image={image} circle size={39} />}
       <div className="raf-comment-field__group">
         <Textarea

--- a/src/components/CommentField.tsx
+++ b/src/components/CommentField.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, FormEvent, useEffect } from 'react';
+import classNames from 'classnames';
 import { EnrichedActivity, Activity } from 'getstream';
 import { Data as EmojiDataSet } from 'emoji-mart';
 
@@ -37,7 +38,7 @@ export const CommentField = <UT extends DefaultUT = DefaultUT, AT extends Defaul
   placeholder,
   trigger,
   targetFeeds,
-  className = 'raf-comment-field',
+  className,
   style,
 }: CommentFieldProps<UT, AT>) => {
   const feed = useFeedContext<UT, AT>();
@@ -76,7 +77,7 @@ export const CommentField = <UT extends DefaultUT = DefaultUT, AT extends Defaul
   }, []);
 
   return (
-    <form onSubmit={handleFormSubmit} className={className} style={style}>
+    <form onSubmit={handleFormSubmit} className={classNames('raf-comment-field', className)} style={style}>
       {image && <Avatar image={image} circle size={39} />}
       <div className="raf-comment-field__group">
         <Textarea

--- a/src/components/CommentItem.test.tsx
+++ b/src/components/CommentItem.test.tsx
@@ -137,7 +137,7 @@ describe('CommentItem', () => {
         >
           <img
             alt=""
-            className="raf-avatar  raf-avatar--circle"
+            className="raf-avatar raf-avatar--circle"
             src="https://randomuser.me/api/portraits/women/20.jpg"
             style={
               Object {

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { EnrichedReaction, UR } from 'getstream';
 
 import { Flex } from './Flex';
@@ -29,7 +30,7 @@ export const CommentItem = <UT extends DefaultUT = DefaultUT, RT extends UR = UR
   onClickHashtag,
   onClickMention,
   onClickUser,
-  className = 'raf-comment-item',
+  className,
   style,
 }: CommentItemProps<UT, RT, CRT>) => {
   const { tDateTimeParser } = useTranslationContext();
@@ -37,7 +38,7 @@ export const CommentItem = <UT extends DefaultUT = DefaultUT, RT extends UR = UR
   const handleUserClick = useOnClickUser<UT, SVGSVGElement | HTMLSpanElement>(onClickUser);
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-comment-item', className)} style={style}>
       <Flex a="flex-start" style={{ padding: '8px 0' }}>
         {user?.data.profileImage && (
           <Avatar onClick={handleUserClick?.(user)} image={user.data.profileImage} circle size={25} />

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -3,27 +3,41 @@ import { EnrichedReaction, UR } from 'getstream';
 
 import { Flex } from './Flex';
 import { Avatar } from './Avatar';
-import { humanizeTimestamp, textRenderer, OnClickUserHandler, useOnClickUser } from '../utils';
+import {
+  humanizeTimestamp,
+  textRenderer,
+  OnClickUserHandler,
+  useOnClickUser,
+  PropsWithElementAttributes,
+} from '../utils';
 import { useTranslationContext } from '../context';
 import { DefaultUT } from '../context/StreamApp';
 
-export type CommentItemProps<UT extends DefaultUT = DefaultUT, RT extends UR = UR, CRT extends UR = UR> = {
-  comment: EnrichedReaction<RT, CRT, UT>;
-  onClickUser?: OnClickUserHandler<UT>;
-} & Partial<Record<'onClickMention' | 'onClickHashtag', (word: string) => void>>;
+export type CommentItemProps<
+  UT extends DefaultUT = DefaultUT,
+  RT extends UR = UR,
+  CRT extends UR = UR
+> = PropsWithElementAttributes<
+  {
+    comment: EnrichedReaction<RT, CRT, UT>;
+    onClickUser?: OnClickUserHandler<UT>;
+  } & Partial<Record<'onClickMention' | 'onClickHashtag', (word: string) => void>>
+>;
 
 export const CommentItem = <UT extends DefaultUT = DefaultUT, RT extends UR = UR, CRT extends UR = UR>({
   comment: { user, created_at, data },
   onClickHashtag,
   onClickMention,
   onClickUser,
+  className = 'raf-comment-item',
+  ...rest
 }: CommentItemProps<UT, RT, CRT>) => {
   const { tDateTimeParser } = useTranslationContext();
 
   const handleUserClick = useOnClickUser<UT, SVGSVGElement | HTMLSpanElement>(onClickUser);
 
   return (
-    <div className="raf-comment-item">
+    <div className={className} {...rest}>
       <Flex a="flex-start" style={{ padding: '8px 0' }}>
         {user?.data.profileImage && (
           <Avatar onClick={handleUserClick?.(user)} image={user.data.profileImage} circle size={25} />

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -30,14 +30,14 @@ export const CommentItem = <UT extends DefaultUT = DefaultUT, RT extends UR = UR
   onClickMention,
   onClickUser,
   className = 'raf-comment-item',
-  ...rest
+  style,
 }: CommentItemProps<UT, RT, CRT>) => {
   const { tDateTimeParser } = useTranslationContext();
 
   const handleUserClick = useOnClickUser<UT, SVGSVGElement | HTMLSpanElement>(onClickUser);
 
   return (
-    <div className={className} {...rest}>
+    <div className={className} style={style}>
       <Flex a="flex-start" style={{ padding: '8px 0' }}>
         {user?.data.profileImage && (
           <Avatar onClick={handleUserClick?.(user)} image={user.data.profileImage} circle size={25} />

--- a/src/components/DataLabel.tsx
+++ b/src/components/DataLabel.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 
-export type DataLabelProps = {
+import { PropsWithElementAttributes } from '../utils';
+
+export type DataLabelProps = PropsWithElementAttributes<{
   data?: string | number;
   label?: string;
-};
+}>;
 
-export const DataLabel = ({ data = 'data', label = 'label' }: DataLabelProps) => {
+export const DataLabel = ({
+  data = 'data',
+  label = 'label',
+  className = 'raf-data-label',
+  ...rest
+}: DataLabelProps) => {
   return (
-    <div className="raf-data-label">
+    <div className={className} {...rest}>
       <span className="raf-data-label__label">{label}</span>
       <span className="raf-data-label__data">{data}</span>
     </div>

--- a/src/components/DataLabel.tsx
+++ b/src/components/DataLabel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 import { PropsWithElementAttributes } from '../utils';
 
@@ -7,9 +8,9 @@ export type DataLabelProps = PropsWithElementAttributes<{
   label?: string;
 }>;
 
-export const DataLabel = ({ data = 'data', label = 'label', className = 'raf-data-label', style }: DataLabelProps) => {
+export const DataLabel = ({ data = 'data', label = 'label', className, style }: DataLabelProps) => {
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-data-label', className)} style={style}>
       <span className="raf-data-label__label">{label}</span>
       <span className="raf-data-label__data">{data}</span>
     </div>

--- a/src/components/DataLabel.tsx
+++ b/src/components/DataLabel.tsx
@@ -7,14 +7,9 @@ export type DataLabelProps = PropsWithElementAttributes<{
   label?: string;
 }>;
 
-export const DataLabel = ({
-  data = 'data',
-  label = 'label',
-  className = 'raf-data-label',
-  ...rest
-}: DataLabelProps) => {
+export const DataLabel = ({ data = 'data', label = 'label', className = 'raf-data-label', style }: DataLabelProps) => {
   return (
-    <div className={className} {...rest}>
+    <div className={className} style={style}>
       <span className="raf-data-label__label">{label}</span>
       <span className="raf-data-label__data">{data}</span>
     </div>

--- a/src/components/Dropdown.test.tsx
+++ b/src/components/Dropdown.test.tsx
@@ -75,7 +75,7 @@ describe('Dropdown', () => {
       </div>
     `);
 
-    fireEvent.click(container);
+    fireEvent.mouseDown(container);
 
     expect(container.firstChild).toMatchInlineSnapshot(`
       <div

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -7,7 +7,7 @@ import { useOnClickOutside } from '../hooks/useOnClickOutside';
 export const Dropdown = ({
   children,
   className = 'raf-dropdown',
-  ...rest
+  style,
 }: PropsWithChildren<PropsWithElementAttributes>) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownBoxReference = useRef<HTMLDivElement | null>(null);
@@ -15,7 +15,7 @@ export const Dropdown = ({
   useOnClickOutside(dropdownBoxReference, () => setIsOpen(false), isOpen);
 
   return (
-    <div className={className} {...rest}>
+    <div className={className} style={style}>
       <IconButton onClick={() => setIsOpen((pv) => !pv)}>
         <svg
           className="raf-dropdown__button"

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,21 +1,18 @@
 import React, { useRef, useState, PropsWithChildren } from 'react';
+import classNames from 'classnames';
 import { IconButton } from 'react-file-utils';
 
 import { PropsWithElementAttributes } from '../utils';
 import { useOnClickOutside } from '../hooks/useOnClickOutside';
 
-export const Dropdown = ({
-  children,
-  className = 'raf-dropdown',
-  style,
-}: PropsWithChildren<PropsWithElementAttributes>) => {
+export const Dropdown = ({ children, className, style }: PropsWithChildren<PropsWithElementAttributes>) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownBoxReference = useRef<HTMLDivElement | null>(null);
 
   useOnClickOutside(dropdownBoxReference, () => setIsOpen(false), isOpen);
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-dropdown', className)} style={style}>
       <IconButton onClick={() => setIsOpen((pv) => !pv)}>
         <svg
           className="raf-dropdown__button"

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,26 +1,22 @@
-import React, { useRef, useState, useEffect, SyntheticEvent } from 'react';
+import React, { useRef, useState, PropsWithChildren } from 'react';
 import { IconButton } from 'react-file-utils';
 
-export const Dropdown = ({ children }: { children?: React.ReactNode }) => {
+import { PropsWithElementAttributes } from '../utils';
+import { useOnClickOutside } from '../hooks/useOnClickOutside';
+
+export const Dropdown = ({
+  children,
+  className = 'raf-dropdown',
+  ...rest
+}: PropsWithChildren<PropsWithElementAttributes>) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownBoxReference = useRef<HTMLDivElement | null>(null);
 
-  const changeMenuVisibility = ({ target }: Event | SyntheticEvent) => {
-    if (dropdownBoxReference.current?.contains(target as Element)) return;
-    setIsOpen((pv) => !pv);
-  };
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    document.addEventListener('click', changeMenuVisibility);
-
-    return () => document.removeEventListener('click', changeMenuVisibility);
-  }, [isOpen]);
+  useOnClickOutside(dropdownBoxReference, () => setIsOpen(false), isOpen);
 
   return (
-    <div className="raf-dropdown">
-      <IconButton onClick={changeMenuVisibility}>
+    <div className={className} {...rest}>
+      <IconButton onClick={() => setIsOpen((pv) => !pv)}>
         <svg
           className="raf-dropdown__button"
           width="12"

--- a/src/components/DropdownPanel.tsx
+++ b/src/components/DropdownPanel.tsx
@@ -1,27 +1,39 @@
 import React, { ReactNode } from 'react';
-import { smartRender, ElementOrComponentOrLiteralType } from '../utils';
+import { smartRender, ElementOrComponentOrLiteralType, PropsWithElementAttributes } from '../utils';
 
-export type DropdownPanelProps = {
+export type DropdownPanelProps = PropsWithElementAttributes<{
   arrow?: boolean;
   children?: ReactNode;
   Footer?: ElementOrComponentOrLiteralType;
   Header?: ElementOrComponentOrLiteralType;
   right?: boolean;
-};
+}>;
 
 /**
  * `DropdownPanel` is a more advanced component used to create a notification dropdown for instance, it comes with three parts:
  * `Header`, `Content` and `Footer`. The content has a limited height and the `overflow` is set to `scroll`.
  */
-export const DropdownPanel = ({ arrow = false, right = false, Header, Footer, children }: DropdownPanelProps) => {
+export const DropdownPanel = ({
+  arrow = false,
+  right = false,
+  Header,
+  Footer,
+  children,
+  className,
+  ...rest
+}: DropdownPanelProps) => {
   return (
     <div
       data-testid="dp-wrapper"
-      className={`raf-dropdown-panel${arrow ? ' raf-dropdown-panel--arrow' : ''} ${
-        right
-          ? ' raf-dropdown-panel--right raf-dropdown-panel--arrow-right'
-          : ' raf-dropdown-panel--left raf-dropdown-panel--arrow-left'
-      }`}
+      className={
+        className ??
+        `raf-dropdown-panel${arrow ? ' raf-dropdown-panel--arrow' : ''} ${
+          right
+            ? ' raf-dropdown-panel--right raf-dropdown-panel--arrow-right'
+            : ' raf-dropdown-panel--left raf-dropdown-panel--arrow-left'
+        }`
+      }
+      {...rest}
     >
       {!!Header && <div className="raf-dropdown-panel__header">{smartRender(Header)}</div>}
       <div className="raf-dropdown-panel__content">{children}</div>

--- a/src/components/DropdownPanel.tsx
+++ b/src/components/DropdownPanel.tsx
@@ -20,7 +20,7 @@ export const DropdownPanel = ({
   Footer,
   children,
   className,
-  ...rest
+  style,
 }: DropdownPanelProps) => {
   return (
     <div
@@ -33,7 +33,7 @@ export const DropdownPanel = ({
             : ' raf-dropdown-panel--left raf-dropdown-panel--arrow-left'
         }`
       }
-      {...rest}
+      style={style}
     >
       {!!Header && <div className="raf-dropdown-panel__header">{smartRender(Header)}</div>}
       <div className="raf-dropdown-panel__content">{children}</div>

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -9,8 +9,9 @@ import { useOnClickOutside } from '../hooks/useOnClickOutside';
 import { EmojiIcon } from './Icons';
 import { TFunction } from 'i18next';
 import { PartialI18n } from 'emoji-mart/dist-es/utils/shared-props';
+import { PropsWithElementAttributes } from '../utils';
 
-export type EmojiPickerProps = {
+export type EmojiPickerProps = PropsWithElementAttributes<{
   /** Override the default emoji dataset, library has a light set of emojis
    * to show more emojis use your own or emoji-mart sets
    * https://github.com/missive/emoji-mart#datasets
@@ -18,7 +19,7 @@ export type EmojiPickerProps = {
   emojiData?: EmojiDataSet;
   i18n?: PartialI18n;
   onSelect?: (emoji: EmojiData) => void;
-};
+}>;
 
 export const getEmojiPickerFieldsTranslations = (t: TFunction): I18n => ({
   search: t('Search'),
@@ -43,7 +44,13 @@ export const getEmojiPickerFieldsTranslations = (t: TFunction): I18n => ({
   },
 });
 
-export const EmojiPicker = ({ emojiData = defaultEmojiData, i18n, onSelect }: EmojiPickerProps) => {
+export const EmojiPicker = ({
+  emojiData = defaultEmojiData,
+  i18n,
+  onSelect,
+  className = 'raf-emoji-picker',
+  ...rest
+}: EmojiPickerProps) => {
   const { t } = useTranslationContext();
   const [open, setOpen] = useState(false);
   const emojiPicker = useRef<HTMLDivElement>(null);
@@ -51,7 +58,7 @@ export const EmojiPicker = ({ emojiData = defaultEmojiData, i18n, onSelect }: Em
   useOnClickOutside(emojiPicker, () => setOpen(false), open);
 
   return (
-    <div className="raf-emoji-picker">
+    <div className={className} {...rest}>
       {open && (
         <div data-testid="picker-wrapper" className="raf-emoji-picker__container" ref={emojiPicker}>
           <NimbleEmojiPicker

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -49,7 +49,7 @@ export const EmojiPicker = ({
   i18n,
   onSelect,
   className = 'raf-emoji-picker',
-  ...rest
+  style,
 }: EmojiPickerProps) => {
   const { t } = useTranslationContext();
   const [open, setOpen] = useState(false);
@@ -58,7 +58,7 @@ export const EmojiPicker = ({
   useOnClickOutside(emojiPicker, () => setOpen(false), open);
 
   return (
-    <div className={className} {...rest}>
+    <div className={className} style={style}>
       {open && (
         <div data-testid="picker-wrapper" className="raf-emoji-picker__container" ref={emojiPicker}>
           <NimbleEmojiPicker

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import classNames from 'classnames';
 import { Data as EmojiDataSet, EmojiData, I18n } from 'emoji-mart';
 // @ts-expect-error
 import NimbleEmojiPicker from 'emoji-mart/dist/components/picker/nimble-picker.js';
@@ -44,13 +45,7 @@ export const getEmojiPickerFieldsTranslations = (t: TFunction): I18n => ({
   },
 });
 
-export const EmojiPicker = ({
-  emojiData = defaultEmojiData,
-  i18n,
-  onSelect,
-  className = 'raf-emoji-picker',
-  style,
-}: EmojiPickerProps) => {
+export const EmojiPicker = ({ emojiData = defaultEmojiData, i18n, onSelect, className, style }: EmojiPickerProps) => {
   const { t } = useTranslationContext();
   const [open, setOpen] = useState(false);
   const emojiPicker = useRef<HTMLDivElement>(null);
@@ -58,7 +53,7 @@ export const EmojiPicker = ({
   useOnClickOutside(emojiPicker, () => setOpen(false), open);
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-emoji-picker', className)} style={style}>
       {open && (
         <div data-testid="picker-wrapper" className="raf-emoji-picker__container" ref={emojiPicker}>
           <NimbleEmojiPicker

--- a/src/components/FeedPlaceholder.tsx
+++ b/src/components/FeedPlaceholder.tsx
@@ -7,11 +7,11 @@ export type FeedPlaceholderProps = PropsWithElementAttributes<{
   text?: string;
 }>;
 
-export const FeedPlaceholder = ({ text, className = 'raf-feed-placeholder', ...rest }: FeedPlaceholderProps) => {
+export const FeedPlaceholder = ({ text, className = 'raf-feed-placeholder', style }: FeedPlaceholderProps) => {
   const { t } = useTranslationContext();
 
   return (
-    <div className={className} {...rest}>
+    <div className={className} style={style}>
       <p>{text || t('No data to display...')}</p>
     </div>
   );

--- a/src/components/FeedPlaceholder.tsx
+++ b/src/components/FeedPlaceholder.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 import { useTranslationContext } from '../context';
 import { PropsWithElementAttributes } from '../utils';
@@ -7,11 +8,11 @@ export type FeedPlaceholderProps = PropsWithElementAttributes<{
   text?: string;
 }>;
 
-export const FeedPlaceholder = ({ text, className = 'raf-feed-placeholder', style }: FeedPlaceholderProps) => {
+export const FeedPlaceholder = ({ text, className, style }: FeedPlaceholderProps) => {
   const { t } = useTranslationContext();
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-feed-placeholder', className)} style={style}>
       <p>{text || t('No data to display...')}</p>
     </div>
   );

--- a/src/components/FeedPlaceholder.tsx
+++ b/src/components/FeedPlaceholder.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
+
 import { useTranslationContext } from '../context';
+import { PropsWithElementAttributes } from '../utils';
 
-export type FeedPlaceholderProps = {
+export type FeedPlaceholderProps = PropsWithElementAttributes<{
   text?: string;
-};
+}>;
 
-export const FeedPlaceholder = ({ text }: FeedPlaceholderProps) => {
+export const FeedPlaceholder = ({ text, className = 'raf-feed-placeholder', ...rest }: FeedPlaceholderProps) => {
   const { t } = useTranslationContext();
 
   return (
-    <div className="raf-feed-placeholder">
+    <div className={className} {...rest}>
       <p>{text || t('No data to display...')}</p>
     </div>
   );

--- a/src/components/Flex.tsx
+++ b/src/components/Flex.tsx
@@ -1,4 +1,5 @@
 import React, { CSSProperties, PropsWithChildren } from 'react';
+import classNames from 'classnames';
 
 import { PropsWithElementAttributes } from '../utils';
 
@@ -12,9 +13,9 @@ export type FlexProps = PropsWithElementAttributes<
   }>
 >;
 
-export const Flex = ({ j, a, js, d = 'row', w = 'nowrap', style, children, className = 'raf-flex' }: FlexProps) => (
+export const Flex = ({ j, a, js, d = 'row', w = 'nowrap', style, children, className }: FlexProps) => (
   <div
-    className={className}
+    className={classNames('raf-flex', className)}
     style={{
       justifyContent: j,
       alignItems: a,

--- a/src/components/Flex.tsx
+++ b/src/components/Flex.tsx
@@ -1,18 +1,20 @@
-import React, { CSSProperties, ReactNode } from 'react';
+import React, { CSSProperties, PropsWithChildren } from 'react';
 
-export type FlexProps = {
-  children: ReactNode;
-  a?: CSSProperties['alignItems'];
-  d?: CSSProperties['flexDirection'];
-  j?: CSSProperties['justifyContent'];
-  js?: CSSProperties['justifySelf'];
-  style?: CSSProperties;
-  w?: CSSProperties['flexWrap'];
-};
+import { PropsWithElementAttributes } from '../utils';
 
-export const Flex = ({ j, a, js, d = 'row', w = 'nowrap', style, children }: FlexProps) => (
+export type FlexProps = PropsWithElementAttributes<
+  PropsWithChildren<{
+    a?: CSSProperties['alignItems'];
+    d?: CSSProperties['flexDirection'];
+    j?: CSSProperties['justifyContent'];
+    js?: CSSProperties['justifySelf'];
+    w?: CSSProperties['flexWrap'];
+  }>
+>;
+
+export const Flex = ({ j, a, js, d = 'row', w = 'nowrap', style, children, className = 'raf-flex' }: FlexProps) => (
   <div
-    className="raf-flex"
+    className={className}
     style={{
       justifyContent: j,
       alignItems: a,

--- a/src/components/FollowButton.tsx
+++ b/src/components/FollowButton.tsx
@@ -1,12 +1,19 @@
 import React, { MouseEvent } from 'react';
 
-export type FollowButtonProps = {
+import { PropsWithElementAttributes } from '../utils';
+
+export type FollowButtonProps = PropsWithElementAttributes<{
   followed?: boolean;
   onClick?: (event: MouseEvent<HTMLDivElement>) => void;
-};
+}>;
 
-export const FollowButton = ({ followed = false, onClick }: FollowButtonProps) => (
-  <div className={`raf-follow-button ${followed ? 'raf-follow-button--active' : ''}`} role="button" onClick={onClick}>
+export const FollowButton = ({ followed = false, onClick, className, ...rest }: FollowButtonProps) => (
+  <div
+    className={className ?? `raf-follow-button ${followed ? 'raf-follow-button--active' : ''}`}
+    role="button"
+    onClick={onClick}
+    {...rest}
+  >
     {followed ? 'Following' : 'Follow'}
   </div>
 );

--- a/src/components/FollowButton.tsx
+++ b/src/components/FollowButton.tsx
@@ -7,12 +7,12 @@ export type FollowButtonProps = PropsWithElementAttributes<{
   onClick?: (event: MouseEvent<HTMLDivElement>) => void;
 }>;
 
-export const FollowButton = ({ followed = false, onClick, className, ...rest }: FollowButtonProps) => (
+export const FollowButton = ({ followed = false, onClick, className, style }: FollowButtonProps) => (
   <div
     className={className ?? `raf-follow-button ${followed ? 'raf-follow-button--active' : ''}`}
     role="button"
     onClick={onClick}
-    {...rest}
+    style={style}
   >
     {followed ? 'Following' : 'Follow'}
   </div>

--- a/src/components/Gallery.test.tsx
+++ b/src/components/Gallery.test.tsx
@@ -38,7 +38,7 @@ describe('Gallery', () => {
         className="raf-gallery"
       >
         <div
-          className="img "
+          className="img"
           onClick={[Function]}
           role="button"
         >
@@ -59,7 +59,7 @@ describe('Gallery', () => {
         className="raf-gallery"
       >
         <div
-          className="img "
+          className="img"
           onClick={[Function]}
           role="button"
         >
@@ -70,7 +70,7 @@ describe('Gallery', () => {
           />
         </div>
         <div
-          className="img "
+          className="img"
           onClick={[Function]}
           role="button"
         >
@@ -81,7 +81,7 @@ describe('Gallery', () => {
           />
         </div>
         <div
-          className="img "
+          className="img"
           onClick={[Function]}
           role="button"
         >
@@ -105,7 +105,7 @@ describe('Gallery', () => {
         class="raf-gallery"
       >
         <div
-          class="img "
+          class="img"
           role="button"
         >
           <img
@@ -130,7 +130,7 @@ describe('Gallery', () => {
         class="raf-gallery"
       >
         <div
-          class="img "
+          class="img"
           role="button"
         >
           <img

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -7,11 +7,11 @@ export type GalleryProps = PropsWithElementAttributes<{
   images?: Array<string>;
 }>;
 
-export const Gallery = ({ images = [], className = 'raf-gallery', ...rest }: GalleryProps) => {
+export const Gallery = ({ images = [], className = 'raf-gallery', style }: GalleryProps) => {
   const [index, setIndex] = useState<number | null>(null);
 
   return (
-    <div className={className} {...rest}>
+    <div className={className} style={style}>
       {images.slice(0, 5).map((image, i) => (
         <div
           role="button"

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
 import Lightbox from 'react-image-lightbox';
 
-export type GalleryProps = {
-  images?: Array<string>;
-};
+import { PropsWithElementAttributes } from '../utils';
 
-export const Gallery = ({ images = [] }: GalleryProps) => {
+export type GalleryProps = PropsWithElementAttributes<{
+  images?: Array<string>;
+}>;
+
+export const Gallery = ({ images = [], className = 'raf-gallery', ...rest }: GalleryProps) => {
   const [index, setIndex] = useState<number | null>(null);
 
   return (
-    <div className="raf-gallery">
+    <div className={className} {...rest}>
       {images.slice(0, 5).map((image, i) => (
         <div
           role="button"

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import classNames from 'classnames';
 import Lightbox from 'react-image-lightbox';
 
 import { PropsWithElementAttributes } from '../utils';
@@ -7,15 +8,15 @@ export type GalleryProps = PropsWithElementAttributes<{
   images?: Array<string>;
 }>;
 
-export const Gallery = ({ images = [], className = 'raf-gallery', style }: GalleryProps) => {
+export const Gallery = ({ images = [], className, style }: GalleryProps) => {
   const [index, setIndex] = useState<number | null>(null);
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-gallery', className)} style={style}>
       {images.slice(0, 5).map((image, i) => (
         <div
           role="button"
-          className={`img ${i === 4 && images.length > 5 ? 'img--last' : ''}`}
+          className={classNames('img', { 'img--last': i === 4 && images.length > 5 })}
           onClick={() => setIndex(i)}
           key={`image-${i}`}
         >

--- a/src/components/IconBadge.tsx
+++ b/src/components/IconBadge.tsx
@@ -19,10 +19,10 @@ export const IconBadge = ({
   unseen = 0,
   showNumber,
   className = 'raf-icon-badge',
-  ...rest
+  style,
 }: IconBadgeProps) => {
   return (
-    <div className={className} role="button" onClick={onClick} {...rest}>
+    <div className={className} role="button" onClick={onClick} style={style}>
       {children ?? <BellIcon />}
       {unseen > 0 && !hidden && (
         <div className="raf-icon-badge__badge" data-testid="unseen-wrapper">

--- a/src/components/IconBadge.tsx
+++ b/src/components/IconBadge.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren, MouseEventHandler } from 'react';
+import classNames from 'classnames';
 
 import { BellIcon } from './Icons';
 import { PropsWithElementAttributes } from '../utils';
@@ -12,17 +13,9 @@ export type IconBadgeProps = PropsWithChildren<
   }>
 >;
 
-export const IconBadge = ({
-  children,
-  onClick,
-  hidden,
-  unseen = 0,
-  showNumber,
-  className = 'raf-icon-badge',
-  style,
-}: IconBadgeProps) => {
+export const IconBadge = ({ children, onClick, hidden, unseen = 0, showNumber, className, style }: IconBadgeProps) => {
   return (
-    <div className={className} role="button" onClick={onClick} style={style}>
+    <div className={classNames('raf-icon-badge', className)} role="button" onClick={onClick} style={style}>
       {children ?? <BellIcon />}
       {unseen > 0 && !hidden && (
         <div className="raf-icon-badge__badge" data-testid="unseen-wrapper">

--- a/src/components/IconBadge.tsx
+++ b/src/components/IconBadge.tsx
@@ -1,17 +1,28 @@
-import React, { ReactNode, MouseEventHandler } from 'react';
+import React, { PropsWithChildren, MouseEventHandler } from 'react';
+
 import { BellIcon } from './Icons';
+import { PropsWithElementAttributes } from '../utils';
 
-export type IconBadgeProps = {
-  children?: ReactNode;
-  hidden?: boolean;
-  onClick?: MouseEventHandler<HTMLDivElement>;
-  showNumber?: boolean;
-  unseen?: number;
-};
+export type IconBadgeProps = PropsWithChildren<
+  PropsWithElementAttributes<{
+    hidden?: boolean;
+    onClick?: MouseEventHandler<HTMLDivElement>;
+    showNumber?: boolean;
+    unseen?: number;
+  }>
+>;
 
-export const IconBadge = ({ children, onClick, hidden, unseen = 0, showNumber }: IconBadgeProps) => {
+export const IconBadge = ({
+  children,
+  onClick,
+  hidden,
+  unseen = 0,
+  showNumber,
+  className = 'raf-icon-badge',
+  ...rest
+}: IconBadgeProps) => {
   return (
-    <div className="raf-icon-badge" role="button" onClick={onClick}>
+    <div className={className} role="button" onClick={onClick} {...rest}>
       {children ?? <BellIcon />}
       {unseen > 0 && !hidden && (
         <div className="raf-icon-badge__badge" data-testid="unseen-wrapper">

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -5,6 +5,7 @@ import { DefaultAT, DefaultUT } from '../context/StreamApp';
 import { ReactionToggleIcon } from './ReactionToggleIcon';
 import { ThumbsUpIcon, Color } from './Icons';
 import { useFeedContext } from '../context';
+import { PropsWithElementAttributes } from '../utils';
 
 export type LikeButtonProps<
   UT extends DefaultUT = DefaultUT,
@@ -12,14 +13,14 @@ export type LikeButtonProps<
   CT extends UR = UR,
   RT extends UR = UR,
   CRT extends UR = UR
-> = {
+> = PropsWithElementAttributes<{
   /** The activity received from stream that should be liked when pressing the LikeButton. */
   activity?: EnrichedActivity<UT, AT, CT, RT, CRT>;
   /** The reaction received from stream that should be liked when pressing the LikeButton. */
   reaction?: EnrichedReaction<RT, CRT, UT>;
   /** onAddReaction supports targetFeeds that you can use to send a notification to the post owner like ["notification:USER_ID"] */
   targetFeeds?: string[];
-};
+}>;
 
 export const LikeButton = <
   UT extends DefaultUT = DefaultUT,
@@ -32,6 +33,8 @@ export const LikeButton = <
   activity,
   reaction,
   targetFeeds,
+  className,
+  style,
 }: LikeButtonProps<UT, AT, CT, RT, CRT>) => {
   const feed = useFeedContext<UT, AT, CT, RT, CRT, PT>();
 
@@ -42,6 +45,8 @@ export const LikeButton = <
 
   return (
     <ReactionToggleIcon
+      className={className}
+      style={style}
       counts={reaction?.children_counts ?? activity?.reaction_counts}
       own_reactions={reaction?.own_children ?? activity?.own_reactions}
       kind="like"

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,13 +1,17 @@
-import React, { MouseEvent, ReactNode } from 'react';
+import React, { MouseEvent, PropsWithChildren } from 'react';
 
-export type LinkProps = {
-  children: ReactNode;
-  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
-  to?: string;
-};
+import { PropsWithElementAttributes } from '../utils';
 
-export const Link = ({ to, children, onClick }: LinkProps) => (
-  <a href={to} className="raf-link" onClick={onClick}>
+export type LinkProps = PropsWithElementAttributes<
+  PropsWithChildren<{
+    onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+    to?: string;
+  }>,
+  HTMLAnchorElement
+>;
+
+export const Link = ({ to, children, onClick, className = 'raf-link', ...rest }: LinkProps) => (
+  <a href={to} className={className} onClick={onClick} {...rest}>
     {children}
   </a>
 );

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEvent, PropsWithChildren } from 'react';
+import classNames from 'classnames';
 
 import { PropsWithElementAttributes } from '../utils';
 
@@ -10,8 +11,8 @@ export type LinkProps = PropsWithElementAttributes<
   HTMLAnchorElement
 >;
 
-export const Link = ({ to, children, onClick, className = 'raf-link', style }: LinkProps) => (
-  <a href={to} className={className} onClick={onClick} style={style}>
+export const Link = ({ to, children, onClick, className, style }: LinkProps) => (
+  <a href={to} className={classNames('raf-link', className)} onClick={onClick} style={style}>
     {children}
   </a>
 );

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -10,8 +10,8 @@ export type LinkProps = PropsWithElementAttributes<
   HTMLAnchorElement
 >;
 
-export const Link = ({ to, children, onClick, className = 'raf-link', ...rest }: LinkProps) => (
-  <a href={to} className={className} onClick={onClick} {...rest}>
+export const Link = ({ to, children, onClick, className = 'raf-link', style }: LinkProps) => (
+  <a href={to} className={className} onClick={onClick} style={style}>
     {children}
   </a>
 );

--- a/src/components/LoadMoreButton.tsx
+++ b/src/components/LoadMoreButton.tsx
@@ -1,20 +1,27 @@
-import React, { ReactNode, MouseEvent } from 'react';
+import React, { PropsWithChildren, MouseEvent } from 'react';
 
 import { Button } from './Button';
-
+import { PropsWithElementAttributes } from '../utils';
 import { useTranslationContext } from '../context';
 
-export type LoadMoreButtonProps = {
-  children?: ReactNode;
-  onClick?: (event?: MouseEvent<HTMLButtonElement>) => void;
-  refreshing?: boolean;
-};
+export type LoadMoreButtonProps = PropsWithElementAttributes<
+  PropsWithChildren<{
+    onClick?: (event?: MouseEvent<HTMLButtonElement>) => void;
+    refreshing?: boolean;
+  }>
+>;
 
-export const LoadMoreButton = ({ onClick, refreshing = false, children }: LoadMoreButtonProps) => {
+export const LoadMoreButton = ({
+  onClick,
+  refreshing = false,
+  children,
+  className = 'raf-load-more-button',
+  ...rest
+}: LoadMoreButtonProps) => {
   const { t } = useTranslationContext();
 
   return (
-    <div className="raf-load-more-button">
+    <div className={className} {...rest}>
       <Button onClick={onClick} buttonStyle="info" disabled={refreshing} loading={refreshing}>
         {children ? children : t('Load more')}
       </Button>

--- a/src/components/LoadMoreButton.tsx
+++ b/src/components/LoadMoreButton.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren, MouseEvent } from 'react';
+import classNames from 'classnames';
 
 import { Button } from './Button';
 import { PropsWithElementAttributes } from '../utils';
@@ -11,17 +12,11 @@ export type LoadMoreButtonProps = PropsWithElementAttributes<
   }>
 >;
 
-export const LoadMoreButton = ({
-  onClick,
-  refreshing = false,
-  children,
-  className = 'raf-load-more-button',
-  style,
-}: LoadMoreButtonProps) => {
+export const LoadMoreButton = ({ onClick, refreshing = false, children, className, style }: LoadMoreButtonProps) => {
   const { t } = useTranslationContext();
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-load-more-button', className)} style={style}>
       <Button onClick={onClick} buttonStyle="info" disabled={refreshing} loading={refreshing}>
         {children ? children : t('Load more')}
       </Button>

--- a/src/components/LoadMoreButton.tsx
+++ b/src/components/LoadMoreButton.tsx
@@ -16,12 +16,12 @@ export const LoadMoreButton = ({
   refreshing = false,
   children,
   className = 'raf-load-more-button',
-  ...rest
+  style,
 }: LoadMoreButtonProps) => {
   const { t } = useTranslationContext();
 
   return (
-    <div className={className} {...rest}>
+    <div className={className} style={style}>
       <Button onClick={onClick} buttonStyle="info" disabled={refreshing} loading={refreshing}>
         {children ? children : t('Load more')}
       </Button>

--- a/src/components/NewActivitiesNotification.tsx
+++ b/src/components/NewActivitiesNotification.tsx
@@ -2,6 +2,7 @@ import React, { MouseEvent } from 'react';
 import { RealTimeMessage } from 'getstream';
 import { Link } from './Link';
 import { useTranslationContext } from '../context';
+import { PropsWithElementAttributes } from '../utils';
 
 type Attributes = {
   addCount: number;
@@ -13,14 +14,17 @@ type Attributes = {
 
 export type LabelFunction = (attributes: Attributes) => string | null;
 
-export type NewActivitiesNotificationProps = {
-  adds?: RealTimeMessage['new'];
-  deletes?: RealTimeMessage['deleted'];
-  labelFunction?: LabelFunction;
-  labelPlural?: string;
-  labelSingle?: string;
-  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
-};
+export type NewActivitiesNotificationProps = PropsWithElementAttributes<
+  {
+    adds?: RealTimeMessage['new'];
+    deletes?: RealTimeMessage['deleted'];
+    labelFunction?: LabelFunction;
+    labelPlural?: string;
+    labelSingle?: string;
+    onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  },
+  HTMLButtonElement
+>;
 
 const generateText = (count: number | string, word: string) => `You have ${count} new ${word}`;
 
@@ -31,6 +35,8 @@ export const NewActivitiesNotification = ({
   labelSingle,
   onClick,
   labelFunction,
+  className = 'raf-new-activities-notification',
+  ...rest
 }: NewActivitiesNotificationProps) => {
   const { t } = useTranslationContext();
 
@@ -62,7 +68,7 @@ export const NewActivitiesNotification = ({
   if (!label) return null;
 
   return (
-    <button className="raf-new-activities-notification" type="button" onClick={onClick}>
+    <button className={className} type="button" onClick={onClick} {...rest}>
       <Link>{label}</Link>
     </button>
   );

--- a/src/components/NewActivitiesNotification.tsx
+++ b/src/components/NewActivitiesNotification.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEvent } from 'react';
+import classNames from 'classnames';
 import { RealTimeMessage } from 'getstream';
 import { Link } from './Link';
 import { useTranslationContext } from '../context';
@@ -35,7 +36,7 @@ export const NewActivitiesNotification = ({
   labelSingle,
   onClick,
   labelFunction,
-  className = 'raf-new-activities-notification',
+  className,
   style,
 }: NewActivitiesNotificationProps) => {
   const { t } = useTranslationContext();
@@ -68,7 +69,12 @@ export const NewActivitiesNotification = ({
   if (!label) return null;
 
   return (
-    <button className={className} type="button" onClick={onClick} style={style}>
+    <button
+      className={classNames('raf-new-activities-notification', className)}
+      type="button"
+      onClick={onClick}
+      style={style}
+    >
       <Link>{label}</Link>
     </button>
   );

--- a/src/components/NewActivitiesNotification.tsx
+++ b/src/components/NewActivitiesNotification.tsx
@@ -36,7 +36,7 @@ export const NewActivitiesNotification = ({
   onClick,
   labelFunction,
   className = 'raf-new-activities-notification',
-  ...rest
+  style,
 }: NewActivitiesNotificationProps) => {
   const { t } = useTranslationContext();
 
@@ -68,7 +68,7 @@ export const NewActivitiesNotification = ({
   if (!label) return null;
 
   return (
-    <button className={className} type="button" onClick={onClick} {...rest}>
+    <button className={className} type="button" onClick={onClick} style={style}>
       <Link>{label}</Link>
     </button>
   );

--- a/src/components/Notification.test.tsx
+++ b/src/components/Notification.test.tsx
@@ -27,7 +27,7 @@ describe('Notification', () => {
       >
         <img
           alt=""
-          className="raf-avatar  raf-avatar--circle"
+          className="raf-avatar raf-avatar--circle"
           src="https://randomuser.me/api/portraits/men/72.jpg"
           style={
             Object {
@@ -105,7 +105,7 @@ describe('Notification', () => {
       >
         <img
           alt=""
-          className="raf-avatar  raf-avatar--circle"
+          className="raf-avatar raf-avatar--circle"
           onClick={[Function]}
           src="https://randomuser.me/api/portraits/women/72.jpg"
           style={
@@ -142,7 +142,7 @@ describe('Notification', () => {
             >
               <img
                 alt=""
-                className="raf-avatar  raf-avatar--circle"
+                className="raf-avatar raf-avatar--circle"
                 onClick={[Function]}
                 src="https://randomuser.me/api/portraits/men/72.jpg"
                 style={
@@ -158,7 +158,7 @@ describe('Notification', () => {
             >
               <img
                 alt=""
-                className="raf-avatar  raf-avatar--circle"
+                className="raf-avatar raf-avatar--circle"
                 onClick={[Function]}
                 src="https://randomuser.me/api/portraits/women/7.jpg"
                 style={

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -7,7 +7,13 @@ import { AvatarGroup } from './AvatarGroup';
 import { AttachedActivity } from './AttachedActivity';
 import { Dropdown } from './Dropdown';
 import { Link } from './Link';
-import { humanizeTimestamp, useOnClickUser, userOrDefault, OnClickUserHandler } from '../utils';
+import {
+  humanizeTimestamp,
+  useOnClickUser,
+  userOrDefault,
+  OnClickUserHandler,
+  PropsWithElementAttributes,
+} from '../utils';
 import { DefaultUT, DefaultAT, useTranslationContext, FeedManager } from '../context';
 
 export type NotificationProps<
@@ -16,7 +22,7 @@ export type NotificationProps<
   CT extends UR = UR,
   RT extends UR = UR,
   CRT extends UR = UR
-> = {
+> = PropsWithElementAttributes<{
   /** The activity group to display in this notification */
   activityGroup: NotificationActivityEnriched<UT, AT, CT, RT, CRT>;
   /** Callback to call when clicking on a notification */
@@ -25,7 +31,7 @@ export type NotificationProps<
   onClickUser?: OnClickUserHandler<UT>;
   /** Callback to mark a notification as read, if not supplied the dropdown used to mark as read will not be shown */
   onMarkAsRead?: FeedManager<UT, AT, CT, RT, CRT>['onMarkAsRead'];
-};
+}>;
 
 const getUsers = <
   UT extends DefaultUT = DefaultUT,
@@ -112,6 +118,8 @@ export const Notification = <
   onMarkAsRead,
   onClickUser,
   onClickNotification,
+  className,
+  ...rest
 }: NotificationProps<UT, AT, CT, RT, CRT>) => {
   const { t, tDateTimeParser } = useTranslationContext();
   const { activities } = activityGroup;
@@ -133,7 +141,8 @@ export const Notification = <
   return (
     <div
       onClick={handleNotificationClick}
-      className={`raf-notification ${activityGroup.is_read ? 'raf-notification--read' : ''}`}
+      className={className ?? `raf-notification ${activityGroup.is_read ? 'raf-notification--read' : ''}`}
+      {...rest}
     >
       <Avatar
         onClick={handleUserClick?.(lastActor as EnrichedUser<UT>)}

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -119,7 +119,7 @@ export const Notification = <
   onClickUser,
   onClickNotification,
   className,
-  ...rest
+  style,
 }: NotificationProps<UT, AT, CT, RT, CRT>) => {
   const { t, tDateTimeParser } = useTranslationContext();
   const { activities } = activityGroup;
@@ -142,7 +142,7 @@ export const Notification = <
     <div
       onClick={handleNotificationClick}
       className={className ?? `raf-notification ${activityGroup.is_read ? 'raf-notification--read' : ''}`}
-      {...rest}
+      style={style}
     >
       <Avatar
         onClick={handleUserClick?.(lastActor as EnrichedUser<UT>)}

--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
 import { UR } from 'getstream';
 
 import { Feed, useFeedContext, DefaultAT, DefaultUT } from '../context';
@@ -36,7 +37,7 @@ const NotificationDropdownInner = <
   Header,
   Icon,
   right,
-  className = 'raf-notification-dropdown',
+  className,
   style,
   ...feedProps
 }: NotificationDropdownProps<UT, AT, CT, RT, CRT, PT>) => {
@@ -50,7 +51,7 @@ const NotificationDropdownInner = <
   }, []);
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-notification-dropdown', className)} style={style}>
       <IconBadge showNumber unseen={feed.unseen} hidden={!feedProps.notify} onClick={() => setOpen(true)}>
         {Icon && smartRender(Icon)}
       </IconBadge>

--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { UR } from 'getstream';
 
 import { Feed, useFeedContext, DefaultAT, DefaultUT } from '../context';
-import { smartRender, ElementOrComponentOrLiteralType } from '../utils';
+import { smartRender, ElementOrComponentOrLiteralType, PropsWithElementAttributes } from '../utils';
 import { useOnClickOutside } from '../hooks/useOnClickOutside';
 import { NotificationFeed, NotificationFeedProps } from './NotificationFeed';
 import { DropdownPanel, DropdownPanelProps } from './DropdownPanel';
@@ -15,11 +15,13 @@ export type NotificationDropdownProps<
   RT extends UR = UR,
   CRT extends UR = UR,
   PT extends UR = UR
-> = {
-  Icon?: ElementOrComponentOrLiteralType;
-  width?: number;
-} & Pick<DropdownPanelProps, 'Footer' | 'Header' | 'right'> &
-  NotificationFeedProps<UT, AT, CT, RT, CRT, PT>;
+> = PropsWithElementAttributes<
+  {
+    Icon?: ElementOrComponentOrLiteralType;
+    width?: number;
+  } & Pick<DropdownPanelProps, 'Footer' | 'Header' | 'right'> &
+    NotificationFeedProps<UT, AT, CT, RT, CRT, PT>
+>;
 
 const NotificationDropdownInner = <
   UT extends DefaultUT = DefaultUT,
@@ -34,6 +36,8 @@ const NotificationDropdownInner = <
   Header,
   Icon,
   right,
+  className = 'raf-notification-dropdown',
+  style,
   ...feedProps
 }: NotificationDropdownProps<UT, AT, CT, RT, CRT, PT>) => {
   const feed = useFeedContext<UT, AT, CT, RT, CRT, PT>();
@@ -46,7 +50,7 @@ const NotificationDropdownInner = <
   }, []);
 
   return (
-    <div className="raf-notification-dropdown">
+    <div className={className} style={style}>
       <IconBadge showNumber unseen={feed.unseen} hidden={!feedProps.notify} onClick={() => setOpen(true)}>
         {Icon && smartRender(Icon)}
       </IconBadge>

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,12 +1,17 @@
-import React, { ReactNode } from 'react';
+import React, { PropsWithChildren } from 'react';
 
-export type PanelProps = {
-  children: ReactNode;
-  panelStyle?: 'rounded' | 'square';
-};
+import { PropsWithElementAttributes } from '../utils';
 
-export const Panel = ({ children, panelStyle = 'rounded' }: PanelProps) => (
-  <div className={`raf-panel raf-panel--${panelStyle}`}>{children}</div>
+export type PanelProps = PropsWithElementAttributes<
+  PropsWithChildren<{
+    panelStyle?: 'rounded' | 'square';
+  }>
+>;
+
+export const Panel = ({ children, panelStyle = 'rounded', className, style }: PanelProps) => (
+  <div className={className ?? `raf-panel raf-panel--${panelStyle}`} style={style}>
+    {children}
+  </div>
 );
 
 type ChildPanelProps = Omit<PanelProps, 'panelStyle'>;
@@ -15,8 +20,22 @@ export type PanelContentProps = ChildPanelProps;
 export type PanelFooterProps = ChildPanelProps;
 export type PanelHeadingProps = ChildPanelProps;
 
-export const PanelContent = ({ children }: PanelContentProps) => <div className="raf-panel-content">{children}</div>;
+export const PanelContent = ({ children, className = 'raf-panel-content', style }: PanelContentProps) => (
+  <div className={className} style={style}>
+    {children}
+  </div>
+);
 
-export const PanelFooter = ({ children }: PanelFooterProps) => <div className="raf-panel-footer">{children}</div>;
+// eslint-disable-next-line sonarjs/no-identical-functions
+export const PanelFooter = ({ children, className = 'raf-panel-footer', style }: PanelFooterProps) => (
+  <div className={className} style={style}>
+    {children}
+  </div>
+);
 
-export const PanelHeading = ({ children }: PanelHeadingProps) => <div className="raf-panel-header">{children}</div>;
+// eslint-disable-next-line sonarjs/no-identical-functions
+export const PanelHeading = ({ children, className = 'raf-panel-header', style }: PanelHeadingProps) => (
+  <div className={className} style={style}>
+    {children}
+  </div>
+);

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren } from 'react';
+import classNames from 'classnames';
 
 import { PropsWithElementAttributes } from '../utils';
 
@@ -20,22 +21,22 @@ export type PanelContentProps = ChildPanelProps;
 export type PanelFooterProps = ChildPanelProps;
 export type PanelHeadingProps = ChildPanelProps;
 
-export const PanelContent = ({ children, className = 'raf-panel-content', style }: PanelContentProps) => (
-  <div className={className} style={style}>
+export const PanelContent = ({ children, className, style }: PanelContentProps) => (
+  <div className={classNames('raf-panel-content', className)} style={style}>
     {children}
   </div>
 );
 
 // eslint-disable-next-line sonarjs/no-identical-functions
-export const PanelFooter = ({ children, className = 'raf-panel-footer', style }: PanelFooterProps) => (
-  <div className={className} style={style}>
+export const PanelFooter = ({ children, className, style }: PanelFooterProps) => (
+  <div className={classNames('raf-panel-footer', className)} style={style}>
     {children}
   </div>
 );
 
 // eslint-disable-next-line sonarjs/no-identical-functions
-export const PanelHeading = ({ children, className = 'raf-panel-header', style }: PanelHeadingProps) => (
-  <div className={className} style={style}>
+export const PanelHeading = ({ children, className, style }: PanelHeadingProps) => (
+  <div className={classNames('raf-panel-header', className)} style={style}>
     {children}
   </div>
 );

--- a/src/components/ReactionIcon.tsx
+++ b/src/components/ReactionIcon.tsx
@@ -1,7 +1,9 @@
 import React, { useMemo, MouseEventHandler } from 'react';
-import { useTranslationContext } from '../context';
 
-export type ReactionIconProps = {
+import { useTranslationContext } from '../context';
+import { PropsWithElementAttributes } from '../utils';
+
+export type ReactionIconProps = PropsWithElementAttributes<{
   /** The reaction counts for the activity */
   counts?: Record<string, number>;
   /** The height of the icon */
@@ -17,9 +19,18 @@ export type ReactionIconProps = {
   onPress?: MouseEventHandler<HTMLDivElement>;
   /** The width of the icon */
   width?: number;
-};
+}>;
 
-export const ReactionIcon = ({ counts, kind, icon, labelPlural, labelSingle, onPress }: ReactionIconProps) => {
+export const ReactionIcon = ({
+  counts,
+  kind,
+  icon,
+  labelPlural,
+  labelSingle,
+  onPress,
+  className = 'raf-reaction-icon',
+  style,
+}: ReactionIconProps) => {
   const { t } = useTranslationContext();
   const count = counts?.[kind ?? ''] ?? 0;
 
@@ -46,7 +57,7 @@ export const ReactionIcon = ({ counts, kind, icon, labelPlural, labelSingle, onP
   }, [count, labelSingle, labelPlural, kind]);
 
   return (
-    <div className="raf-reaction-icon" role="button" onClick={onPress}>
+    <div className={className} role="button" onClick={onPress} style={style}>
       {icon && (typeof icon === 'string' ? <img className="raf-reaction-icon__image" src={icon} alt="" /> : icon)}
       <p className="raf-reaction-icon__label">{label}</p>
     </div>

--- a/src/components/ReactionIcon.tsx
+++ b/src/components/ReactionIcon.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, MouseEventHandler } from 'react';
+import classNames from 'classnames';
 
 import { useTranslationContext } from '../context';
 import { PropsWithElementAttributes } from '../utils';
@@ -28,7 +29,7 @@ export const ReactionIcon = ({
   labelPlural,
   labelSingle,
   onPress,
-  className = 'raf-reaction-icon',
+  className,
   style,
 }: ReactionIconProps) => {
   const { t } = useTranslationContext();
@@ -57,7 +58,7 @@ export const ReactionIcon = ({
   }, [count, labelSingle, labelPlural, kind]);
 
   return (
-    <div className={className} role="button" onClick={onPress} style={style}>
+    <div className={classNames('raf-reaction-icon', className)} role="button" onClick={onPress} style={style}>
       {icon && (typeof icon === 'string' ? <img className="raf-reaction-icon__image" src={icon} alt="" /> : icon)}
       <p className="raf-reaction-icon__label">{label}</p>
     </div>

--- a/src/components/ReactionToggleIcon.tsx
+++ b/src/components/ReactionToggleIcon.tsx
@@ -3,26 +3,35 @@ import { ReactionsRecords, UR } from 'getstream';
 
 import { ReactionIcon, ReactionIconProps } from './ReactionIcon';
 import { DefaultUT } from '../context/StreamApp';
+import { PropsWithElementAttributes } from '../utils';
 
-type ReactionToggleIconProps<UT extends DefaultUT = DefaultUT, RT extends UR = UR, CRT extends UR = UR> = {
-  /** The icon to show when the user has done this reaction (e.g. a filled in heart) */
-  activeIcon: ReactionIconProps['icon'];
-  /** The icon to show when the user has not done this reaction yet (e.g. an empty in heart) */
-  inactiveIcon: ReactionIconProps['icon'];
-  /** The map with own reactions */
-  own_reactions?: ReactionsRecords<RT, CRT, UT> | Record<string, CRT>;
-} & Omit<ReactionIconProps, 'icon'>;
+type ReactionToggleIconProps<
+  UT extends DefaultUT = DefaultUT,
+  RT extends UR = UR,
+  CRT extends UR = UR
+> = PropsWithElementAttributes<
+  {
+    /** The icon to show when the user has done this reaction (e.g. a filled in heart) */
+    activeIcon: ReactionIconProps['icon'];
+    /** The icon to show when the user has not done this reaction yet (e.g. an empty in heart) */
+    inactiveIcon: ReactionIconProps['icon'];
+    /** The map with own reactions */
+    own_reactions?: ReactionsRecords<RT, CRT, UT> | Record<string, CRT>;
+  } & Omit<ReactionIconProps, 'icon'>
+>;
 
 export const ReactionToggleIcon = <UT extends DefaultUT = DefaultUT, RT extends UR = UR, CRT extends UR = UR>({
   inactiveIcon,
   activeIcon,
   own_reactions: ownReactions,
   kind,
+  className = 'raf-reaction-toggle-icon',
+  style,
   ...restProps
 }: ReactionToggleIconProps<UT, RT, CRT>) => {
   const icon = ownReactions?.[kind ?? '']?.length ? activeIcon : inactiveIcon;
   return (
-    <div className="raf-reaction-toggle-icon">
+    <div className={className} style={style}>
       <ReactionIcon icon={icon} kind={kind} {...restProps} />
     </div>
   );

--- a/src/components/ReactionToggleIcon.tsx
+++ b/src/components/ReactionToggleIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { ReactionsRecords, UR } from 'getstream';
 
 import { ReactionIcon, ReactionIconProps } from './ReactionIcon';
@@ -25,13 +26,13 @@ export const ReactionToggleIcon = <UT extends DefaultUT = DefaultUT, RT extends 
   activeIcon,
   own_reactions: ownReactions,
   kind,
-  className = 'raf-reaction-toggle-icon',
+  className,
   style,
   ...restProps
 }: ReactionToggleIconProps<UT, RT, CRT>) => {
   const icon = ownReactions?.[kind ?? '']?.length ? activeIcon : inactiveIcon;
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-reaction-toggle-icon', className)} style={style}>
       <ReactionIcon icon={icon} kind={kind} {...restProps} />
     </div>
   );

--- a/src/components/RepostButton.tsx
+++ b/src/components/RepostButton.tsx
@@ -4,6 +4,7 @@ import { Activity, EnrichedActivity, UR } from 'getstream';
 import { ReactionToggleIcon } from './ReactionToggleIcon';
 import { useFeedContext, DefaultAT, DefaultUT, useStreamContext } from '../context';
 import { RepostIcon, Color } from './Icons';
+import { PropsWithElementAttributes } from '../utils';
 
 export type RepostButtonProps<
   UT extends DefaultUT = DefaultUT,
@@ -11,7 +12,7 @@ export type RepostButtonProps<
   CT extends UR = UR,
   RT extends UR = UR,
   CRT extends UR = UR
-> = {
+> = PropsWithElementAttributes<{
   /** The activity received for stream for which to show the repost button. This is
    * used to initialize the toggle state and the counter. */
   activity: EnrichedActivity<UT, AT, CT, RT, CRT>;
@@ -24,7 +25,7 @@ export type RepostButtonProps<
   targetFeeds?: string[];
   /** The user_id part of the feed that the activity should be reposted to, default to current user id */
   userId?: string;
-};
+}>;
 
 /**
  * A repost button ready to be embedded as Activity footer
@@ -42,6 +43,8 @@ export const RepostButton = <
   userId,
   repostData,
   targetFeeds = [],
+  className,
+  style,
 }: RepostButtonProps<UT, AT, CT, RT, CRT>) => {
   const feed = useFeedContext<UT, AT, CT, RT, CRT, PT>();
   const app = useStreamContext<UT, AT, CT, RT, CRT, PT>();
@@ -64,6 +67,8 @@ export const RepostButton = <
       }
       activeIcon={<RepostIcon style={{ color: Color.Active }} />}
       inactiveIcon={<RepostIcon style={{ color: Color.Inactive }} />}
+      className={className}
+      style={style}
     />
   );
 };

--- a/src/components/StatusUpdateForm/StatusUpdateForm.tsx
+++ b/src/components/StatusUpdateForm/StatusUpdateForm.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-file-utils';
 
 import { DefaultAT, DefaultUT, useTranslationContext } from '../../context';
+import { PropsWithElementAttributes } from '../../utils';
 import { useStatusUpdateForm } from './useStatusUpdateForm';
 import { Panel, PanelContent, PanelHeading, PanelFooter } from '../Panel';
 import { Textarea, TextareaProps } from '../Textarea';
@@ -24,7 +25,7 @@ import { Button } from '../Button';
 import { Title } from '../Title';
 import { BookmarkIcon } from '../Icons';
 
-export type StatusUpdateFormProps<AT extends DefaultAT = DefaultAT> = {
+export type StatusUpdateFormProps<AT extends DefaultAT = DefaultAT> = PropsWithElementAttributes<{
   /** The verb that should be used to post the activity, default to "post" */
   activityVerb?: string;
   /** Override Post request */
@@ -63,7 +64,7 @@ export type StatusUpdateFormProps<AT extends DefaultAT = DefaultAT> = {
   trigger?: TextareaProps['trigger'];
   /** The user_id part of the feed that the activity should be posted to  */
   userId?: string;
-};
+}>;
 
 export function StatusUpdateForm<
   UT extends DefaultUT = DefaultUT,
@@ -84,6 +85,8 @@ export function StatusUpdateForm<
   doRequest,
   userId,
   onSuccess,
+  style,
+  className,
 }: StatusUpdateFormProps<AT>) {
   const { t } = useTranslationContext();
   const state = useStatusUpdateForm<UT, AT, CT, RT, CRT, PT>({
@@ -96,7 +99,7 @@ export function StatusUpdateForm<
   });
 
   return (
-    <Panel>
+    <Panel style={style} className={className}>
       <form onSubmit={state.onSubmitForm}>
         <ImageDropzone handleFiles={state.uploadNewFiles}>
           <PanelHeading>{Header ?? <Title>{t('New Post')}</Title>}</PanelHeading>

--- a/src/components/Textarea.tsx
+++ b/src/components/Textarea.tsx
@@ -7,8 +7,9 @@ import { NimbleEmojiIndex, Data as EmojiDataSet } from 'emoji-mart';
 // @ts-expect-error
 import EmojiIndex from 'emoji-mart/dist/utils/emoji-index/nimble-emoji-index';
 import defaultEmojiData from '../utils/emojiData';
+import { PropsWithElementAttributes } from '../utils';
 
-export type TextareaProps = {
+export type TextareaProps = PropsWithElementAttributes<{
   /** Override the default emoji dataset, library has a light set of emojis
    * to show more emojis use your own or emoji-mart sets
    * https://github.com/missive/emoji-mart#datasets
@@ -26,7 +27,7 @@ export type TextareaProps = {
    */
   trigger?: TriggerType<UR>;
   value?: string;
-};
+}>;
 
 const emojiTrigger: (emojiData: EmojiDataSet) => TriggerType<BaseEmoji> = (emojiData) => {
   const emojiIndex = new EmojiIndex(emojiData) as NimbleEmojiIndex;
@@ -56,6 +57,8 @@ export const Textarea = ({
   rows = 3,
   trigger = {},
   value,
+  className = 'raf-textarea__textarea',
+  style,
 }: TextareaProps) => {
   const emoji = useMemo(() => emojiTrigger(emojiData), []);
 
@@ -76,7 +79,8 @@ export const Textarea = ({
       }
       rows={rows}
       maxLength={maxLength}
-      className="raf-textarea__textarea"
+      className={className}
+      style={style}
       containerClassName="raf-textarea"
       dropdownClassName="raf-emojisearch"
       listClassName="raf-emojisearch__list"

--- a/src/components/Textarea.tsx
+++ b/src/components/Textarea.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import classNames from 'classnames';
 import ReactTextareaAutocomplete, { TriggerType } from '@webscopeio/react-textarea-autocomplete';
 import { LoadingIndicator } from 'react-file-utils';
 import { BaseEmoji } from 'emoji-mart';
@@ -57,7 +58,7 @@ export const Textarea = ({
   rows = 3,
   trigger = {},
   value,
-  className = 'raf-textarea__textarea',
+  className,
   style,
 }: TextareaProps) => {
   const emoji = useMemo(() => emojiTrigger(emojiData), []);
@@ -79,7 +80,7 @@ export const Textarea = ({
       }
       rows={rows}
       maxLength={maxLength}
-      className={className}
+      className={classNames('raf-textarea__textarea', className)}
       style={style}
       containerClassName="raf-textarea"
       dropdownClassName="raf-emojisearch"

--- a/src/components/TimeHeader.tsx
+++ b/src/components/TimeHeader.tsx
@@ -1,12 +1,13 @@
 import React, { PropsWithChildren } from 'react';
+import classNames from 'classnames';
 
 import { Title } from './Title';
 import { PropsWithElementAttributes } from '../utils';
 
 export type TimeHeaderProps = PropsWithChildren<PropsWithElementAttributes>;
 
-export const TimeHeader = ({ children, className = 'raf-time-header', style }: TimeHeaderProps) => (
-  <div className={className} style={style}>
+export const TimeHeader = ({ children, className, style }: TimeHeaderProps) => (
+  <div className={classNames('raf-time-header', className)} style={style}>
     <Title size={14}>{children}</Title>
     <div className="raf-time-header__line" />
   </div>

--- a/src/components/TimeHeader.tsx
+++ b/src/components/TimeHeader.tsx
@@ -1,12 +1,12 @@
-import React, { ReactNode } from 'react';
+import React, { PropsWithChildren } from 'react';
+
 import { Title } from './Title';
+import { PropsWithElementAttributes } from '../utils';
 
-export type TimeHeaderProps = {
-  children?: ReactNode;
-};
+export type TimeHeaderProps = PropsWithChildren<PropsWithElementAttributes>;
 
-export const TimeHeader = ({ children }: TimeHeaderProps) => (
-  <div className="raf-time-header">
+export const TimeHeader = ({ children, className = 'raf-time-header', style }: TimeHeaderProps) => (
+  <div className={className} style={style}>
     <Title size={14}>{children}</Title>
     <div className="raf-time-header__line" />
   </div>

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,12 +1,15 @@
-import React, { ReactNode } from 'react';
+import React, { PropsWithChildren } from 'react';
 
-export type TitleProps = {
-  children?: ReactNode;
-  size?: number;
-};
+import { PropsWithElementAttributes } from '../utils';
 
-export const Title = ({ size = 18, children }: TitleProps) => (
-  <div className="raf-title" style={{ fontSize: size }}>
+export type TitleProps = PropsWithElementAttributes<
+  PropsWithChildren<{
+    size?: number;
+  }>
+>;
+
+export const Title = ({ size = 18, children, className = 'raf-title', style = { fontSize: size } }: TitleProps) => (
+  <div className={className} style={style}>
     {children}
   </div>
 );

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren } from 'react';
+import classNames from 'classnames';
 
 import { PropsWithElementAttributes } from '../utils';
 
@@ -8,8 +9,8 @@ export type TitleProps = PropsWithElementAttributes<
   }>
 >;
 
-export const Title = ({ size = 18, children, className = 'raf-title', style = { fontSize: size } }: TitleProps) => (
-  <div className={className} style={style}>
+export const Title = ({ size = 18, children, className, style = { fontSize: size } }: TitleProps) => (
+  <div className={classNames('raf-title', className)} style={style}>
     {children}
   </div>
 );

--- a/src/components/UserBar.test.tsx
+++ b/src/components/UserBar.test.tsx
@@ -57,7 +57,7 @@ describe('UserBar', () => {
       >
         <img
           alt=""
-          className="raf-avatar  raf-avatar--circle"
+          className="raf-avatar raf-avatar--circle"
           onClick={[Function]}
           src="https://i.pinimg.com/originals/4f/a1/41/4fa141173a1b04470bb2f850bc5da13b.png"
           style={

--- a/src/components/UserBar.tsx
+++ b/src/components/UserBar.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, MouseEventHandler } from 'react';
+import classNames from 'classnames';
 
 import { humanizeTimestamp } from '../utils';
 import { Avatar } from './Avatar';
@@ -28,7 +29,7 @@ export const UserBar = ({
   username,
   onClickUser,
   avatar,
-  className = 'raf-user-bar',
+  className,
   style,
 }: UserBarProps) => {
   const { tDateTimeParser } = useTranslationContext();
@@ -42,7 +43,7 @@ export const UserBar = ({
   );
 
   return (
-    <div className={className} style={style}>
+    <div className={classNames('raf-user-bar', className)} style={style}>
       {avatar && <Avatar onClick={onClickUser} size={50} circle image={avatar} />}
       <div className="raf-user-bar__details">
         <p data-testid="user-bar-username" className="raf-user-bar__username" onClick={onClickUser}>

--- a/src/components/UserBar.tsx
+++ b/src/components/UserBar.tsx
@@ -2,10 +2,10 @@ import React, { useMemo, MouseEventHandler } from 'react';
 
 import { humanizeTimestamp } from '../utils';
 import { Avatar } from './Avatar';
-import { smartRender, ElementOrComponentOrLiteralType } from '../utils';
+import { smartRender, ElementOrComponentOrLiteralType, PropsWithElementAttributes } from '../utils';
 import { useTranslationContext } from '../context';
 
-export type UserBarProps = {
+export type UserBarProps = PropsWithElementAttributes<{
   username: string;
   AfterUsername?: React.ReactNode;
   avatar?: string;
@@ -16,7 +16,7 @@ export type UserBarProps = {
   subtitle?: string;
   time?: string; // text that should be displayed as the time
   timestamp?: string | number | Date; // a timestamp that should be humanized
-};
+}>;
 
 export const UserBar = ({
   time,
@@ -28,6 +28,8 @@ export const UserBar = ({
   username,
   onClickUser,
   avatar,
+  className = 'raf-user-bar',
+  style,
 }: UserBarProps) => {
   const { tDateTimeParser } = useTranslationContext();
 
@@ -40,7 +42,7 @@ export const UserBar = ({
   );
 
   return (
-    <div className="raf-user-bar">
+    <div className={className} style={style}>
       {avatar && <Avatar onClick={onClickUser} size={50} circle image={avatar} />}
       <div className="raf-user-bar__details">
         <p data-testid="user-bar-username" className="raf-user-bar__username" onClick={onClickUser}>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -179,13 +179,6 @@ export const useOnClickUser = <
     [onClickUser],
   );
 
-// export type PropsWithWrapper<T extends { elementType?: HTMLElement; props?: UR } = UR> = T['props'] & {
-//   wrapperProps?: DetailedHTMLProps<
-//     HTMLAttributes<T['elementType'] extends HTMLElement ? T['elementType'] : HTMLDivElement>,
-//     T['elementType'] extends HTMLElement ? T['elementType'] : HTMLDivElement
-//   >;
-// };
-
 export type PropsWithElementAttributes<T extends UR = UR, E extends HTMLElement = HTMLDivElement> = T &
   Pick<DetailedHTMLProps<HTMLAttributes<E>, E>, 'className' | 'style'>;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import React, { useMemo, MouseEvent } from 'react';
+import React, { useMemo, MouseEvent, DetailedHTMLProps, HTMLAttributes } from 'react';
 import URL from 'url-parse';
 import Dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -155,10 +155,6 @@ export function sanitizeURL(url?: string) {
   return undefined;
 }
 
-/**
- *
- * @param {string | undefined} url
- */
 export const trimURL = (url?: string) =>
   url
     ?.replace(/^(?:https?:\/\/)?(?:www\.)?/i, '')
@@ -182,6 +178,16 @@ export const useOnClickUser = <
         : undefined,
     [onClickUser],
   );
+
+// export type PropsWithWrapper<T extends { elementType?: HTMLElement; props?: UR } = UR> = T['props'] & {
+//   wrapperProps?: DetailedHTMLProps<
+//     HTMLAttributes<T['elementType'] extends HTMLElement ? T['elementType'] : HTMLDivElement>,
+//     T['elementType'] extends HTMLElement ? T['elementType'] : HTMLDivElement
+//   >;
+// };
+
+export type PropsWithElementAttributes<T extends UR = UR, E extends HTMLElement = HTMLDivElement> = T &
+  Pick<DetailedHTMLProps<HTMLAttributes<E>, E>, 'className' | 'style'>;
 
 export * from './textRenderer';
 export * from './smartRender';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4900,6 +4900,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
 clean-css@4.2.x:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"


### PR DESCRIPTION
Allows users to style default components with libraries like [Styled Components 💅](https://github.com/styled-components/styled-components) or [Emotion](https://github.com/styled-components/styled-components).

Example with styled-components:
```tsx
import styled from "styled-components";
import { Activity } from "react-activity-feed";

const CustomActivity = styled(Activity)`
  background-color: ${({ activity: { verb } }) => verb === "repost" ? "hotpink" : "white"};
  color: #ddd;
`
```