### PR TITLE
fix return type definition for Feed hook doReactionAddRequest

### DIFF
--- a/src/context/Feed.tsx
+++ b/src/context/Feed.tsx
@@ -94,7 +94,7 @@ export type FeedProps<
     activity: Activity<AT>,
     data?: RT,
     options?: ReactionAddOptions,
-  ) => ReactionAPIResponse<RT>;
+  ) => Promise<ReactionAPIResponse<RT>>;
   /** Override reaction delete request */
   doReactionDeleteRequest?: DeleteRequestFn;
   /** Override reactions filter request */


### PR DESCRIPTION
Fix the return value type for `FeedProps.doReactionAddRequest` hook. The function should return `Promise<ReactionAPIResponse<RT>>` and not the value of `ReactionAPIResponse<RT>` directly.