### PR TITLE
fix removal of child reaction from latest_children

### DIFF
--- a/src/context/FeedManager.tsx
+++ b/src/context/FeedManager.tsx
@@ -406,7 +406,7 @@ export class FeedManager<
           .updateIn([...path, 'own_children', kind], (v = immutable.List()) =>
             v.remove(v.findIndex((r: CU) => r.get('id') === id)),
           )
-          .updateIn([...path, 'children', kind], (v = immutable.List()) =>
+          .updateIn([...path, 'latest_children', kind], (v = immutable.List()) =>
             v.remove(v.findIndex((r: CU) => r.get('id') === id)),
           );
       }


### PR DESCRIPTION
Fixing typo that prevented removal of child reaction object from `latest_reactions` array in the feed state in `FeedManager.onRemoveChildReaction`.