### PR TITLE
FIX: Feed, FlatFeed, NotificationFeed - `options` change wouldn't trigger refresh  

### DIFF
--- a/src/components/FlatFeed.tsx
+++ b/src/components/FlatFeed.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { EnrichedActivity, UR } from 'getstream';
 import { LoadingIndicator as DefaultLoadingIndicator, LoadingIndicatorProps } from 'react-file-utils';
 
@@ -95,10 +95,6 @@ const FlatFeedInner = <
   const { t } = useTranslationContext();
 
   const refreshFeed = () => feed.refresh(options);
-
-  useEffect(() => {
-    refreshFeed();
-  }, [feed.feedGroup, feed.userId]);
 
   if (feed.refreshing && !feed.hasDoneRequest) {
     return <div className="raf-loading-indicator">{smartRender<LoadingIndicatorProps>(LoadingIndicator)}</div>;

--- a/src/components/NotificationFeed.tsx
+++ b/src/components/NotificationFeed.tsx
@@ -85,14 +85,13 @@ const NotificationFeedInner = <
 
   const refreshFeed = () => feed.refresh(options);
 
-  useEffect(() => {
-    refreshFeed();
-
-    return () => {
+  useEffect(
+    () => () => {
       feed.activities.clear();
       feed.activityOrder.splice(0, feed.activityOrder.length);
-    };
-  }, [feed.feedGroup, feed.userId]);
+    },
+    [feed.feedGroup, feed.userId],
+  );
 
   if (feed.refreshing && !feed.hasDoneRequest) {
     return <div className="raf-loading-indicator">{smartRender<LoadingIndicatorProps>(LoadingIndicator)}</div>;

--- a/src/components/NotificationFeed.tsx
+++ b/src/components/NotificationFeed.tsx
@@ -85,13 +85,12 @@ const NotificationFeedInner = <
 
   const refreshFeed = () => feed.refresh(options);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    return () => {
       feed.activities.clear();
       feed.activityOrder.splice(0, feed.activityOrder.length);
-    },
-    [feed.feedGroup, feed.userId],
-  );
+    };
+  }, [feed.feedGroup, feed.userId]);
 
   if (feed.refreshing && !feed.hasDoneRequest) {
     return <div className="raf-loading-indicator">{smartRender<LoadingIndicatorProps>(LoadingIndicator)}</div>;

--- a/src/context/Feed.tsx
+++ b/src/context/Feed.tsx
@@ -179,7 +179,7 @@ export function Feed<
     if (!manager) return;
 
     if (optionsReference.current) {
-      manager.setOptions(optionsReference.current);
+      manager.props.options = optionsReference.current;
     }
 
     manager.refresh();

--- a/src/context/Feed.tsx
+++ b/src/context/Feed.tsx
@@ -174,9 +174,7 @@ export function Feed<
     const forceUpdate = () => setForceUpdateState((prevState) => prevState + 1);
     if (manager) manager.props.notify = notify;
     manager?.register(forceUpdate);
-    return () => {
-      manager?.unregister(forceUpdate);
-    };
+    return () => manager?.unregister(forceUpdate);
   }, [manager, notify]);
 
   useEffect(() => {

--- a/src/context/Feed.tsx
+++ b/src/context/Feed.tsx
@@ -13,7 +13,7 @@ import {
   ReactionFilterConditions,
 } from 'getstream';
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import { FeedManager } from './FeedManager';
 import { DefaultAT, DefaultUT, useStreamContext } from './StreamApp';
@@ -172,6 +172,7 @@ export function Feed<
 
   useEffect(() => {
     const forceUpdate = () => setForceUpdateState((prevState) => prevState + 1);
+    if (manager) manager.props.notify = notify;
     manager?.register(forceUpdate);
     return () => {
       manager?.unregister(forceUpdate);
@@ -180,7 +181,7 @@ export function Feed<
 
   useEffect(() => {
     manager?.refresh(optionsReference.current);
-  }, [optionsReference.current]);
+  }, [optionsReference.current, manager]);
 
   if (!manager) return null;
 

--- a/src/context/Feed.tsx
+++ b/src/context/Feed.tsx
@@ -15,7 +15,6 @@ import {
 
 import { FeedManager } from './FeedManager';
 import { DefaultAT, DefaultUT, useStreamContext } from './StreamApp';
-// import { useDeepCompareEffect } from '../utils';
 import isEqual from 'lodash/isEqual';
 
 export type FeedContextValue<
@@ -155,9 +154,7 @@ export function Feed<
 
   const optionsReference = useRef<GetFeedOptions | undefined>();
 
-  if (!optionsReference.current || !isEqual(optionsReference.current, options)) {
-    optionsReference.current = options;
-  }
+  if (!isEqual(optionsReference.current, options)) optionsReference.current = options;
 
   const feedId = client?.feed(feedGroup, userId).id;
 
@@ -182,7 +179,7 @@ export function Feed<
     if (!manager) return;
 
     if (optionsReference.current) {
-      manager.options = optionsReference.current;
+      manager.setOptions(optionsReference.current);
     }
 
     manager.refresh();

--- a/src/context/FeedManager.tsx
+++ b/src/context/FeedManager.tsx
@@ -992,6 +992,7 @@ export class FeedManager<
     return this.setState(newState);
   };
 
+  // TODO: deprecate async in next major release
   // eslint-disable-next-line require-await
   subscribe = async () => {
     if (!this.props.notify) return;

--- a/src/context/FeedManager.tsx
+++ b/src/context/FeedManager.tsx
@@ -992,35 +992,34 @@ export class FeedManager<
     return this.setState(newState);
   };
 
+  // eslint-disable-next-line require-await
   subscribe = async () => {
-    if (this.props.notify) {
-      const feed = this.feed();
-      await this.setState((prevState) => {
-        if (prevState.subscription) {
-          return {};
-        }
+    if (!this.props.notify) return;
 
-        const subscription = feed.subscribe((data) => {
-          this.setState((prevState) => {
-            const numActivityDiff = data.new.length - data.deleted.length;
+    const feed = this.feed();
+    this.setState((prevState) => {
+      if (prevState.subscription) return {};
 
-            return {
-              realtimeAdds: prevState.realtimeAdds.concat(data.new),
-              realtimeDeletes: prevState.realtimeDeletes.concat(data.deleted),
-              unread: prevState.unread + numActivityDiff,
-              unseen: prevState.unseen + numActivityDiff,
-            };
-          });
+      const subscription = feed.subscribe((data) => {
+        this.setState((prevState) => {
+          const numActivityDiff = data.new.length - data.deleted.length;
+
+          return {
+            realtimeAdds: prevState.realtimeAdds.concat(data.new),
+            realtimeDeletes: prevState.realtimeDeletes.concat(data.deleted),
+            unread: prevState.unread + numActivityDiff,
+            unseen: prevState.unseen + numActivityDiff,
+          };
         });
-
-        subscription.then(
-          () => console.log(`now listening to changes in realtime for ${this.feed().id}`),
-          (err) => console.error(err),
-        );
-
-        return { subscription };
       });
-    }
+
+      subscription.then(
+        () => console.log(`now listening to changes in realtime for ${this.feed().id}`),
+        (err) => console.error(err),
+      );
+
+      return { subscription };
+    });
   };
 
   unsubscribe = async () => {
@@ -1031,8 +1030,12 @@ export class FeedManager<
 
     try {
       await subscription;
+
+      this.setState({ subscription: null });
+
       // @ts-expect-error
       subscription?.cancel();
+
       console.log(`stopped listening to changes in realtime for ${this.feed().id}`);
     } catch (err) {
       console.error(err);

--- a/src/context/FeedManager.tsx
+++ b/src/context/FeedManager.tsx
@@ -146,7 +146,7 @@ export class FeedManager<
     this.state.lastReverseResponse = { next: previousUrl };
   }
 
-  set options(newOptions: Partial<GetFeedOptions>) {
+  setOptions(newOptions: Partial<GetFeedOptions>) {
     this.props.options = this.getOptions(newOptions);
   }
 

--- a/src/context/FeedManager.tsx
+++ b/src/context/FeedManager.tsx
@@ -146,6 +146,10 @@ export class FeedManager<
     this.state.lastReverseResponse = { next: previousUrl };
   }
 
+  set options(newOptions: Partial<GetFeedOptions>) {
+    this.props.options = this.getOptions(newOptions);
+  }
+
   register(callback: UpdateTriggeredCallback) {
     this.registeredCallbacks.push(callback);
     this.subscribe();

--- a/src/context/FeedManager.tsx
+++ b/src/context/FeedManager.tsx
@@ -146,10 +146,6 @@ export class FeedManager<
     this.state.lastReverseResponse = { next: previousUrl };
   }
 
-  setOptions(newOptions: Partial<GetFeedOptions>) {
-    this.props.options = this.getOptions(newOptions);
-  }
-
   register(callback: UpdateTriggeredCallback) {
     this.registeredCallbacks.push(callback);
     this.subscribe();

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,13 @@
-import React, { useMemo, MouseEvent, DetailedHTMLProps, HTMLAttributes } from 'react';
+import React, {
+  useMemo,
+  MouseEvent,
+  DetailedHTMLProps,
+  HTMLAttributes,
+  useEffect,
+  useRef,
+  DependencyList,
+  EffectCallback,
+} from 'react';
 import URL from 'url-parse';
 import Dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -7,6 +16,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { EnrichedUser, UR } from 'getstream';
 import { TDateTimeParser } from '../i18n/Streami18n';
 import { DefaultUT } from '../context/StreamApp';
+import isEqual from 'lodash/isEqual';
 
 Dayjs.extend(utc);
 Dayjs.extend(minMax);
@@ -188,6 +198,16 @@ export const useOnClickUser = <
 
 export type PropsWithElementAttributes<T extends UR = UR, E extends HTMLElement = HTMLDivElement> = T &
   Pick<DetailedHTMLProps<HTMLAttributes<E>, E>, 'className' | 'style'>;
+
+export const useDeepCompareEffect = <D extends DependencyList>(effect: EffectCallback, dependencies: D) => {
+  const reference = useRef<D | undefined>();
+
+  if (!reference.current || !isEqual(dependencies, reference.current)) {
+    reference.current = dependencies;
+  }
+
+  useEffect(effect, reference.current);
+};
 
 export * from './textRenderer';
 export * from './smartRender';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,13 +1,4 @@
-import React, {
-  useMemo,
-  MouseEvent,
-  DetailedHTMLProps,
-  HTMLAttributes,
-  useEffect,
-  useRef,
-  DependencyList,
-  EffectCallback,
-} from 'react';
+import React, { useMemo, MouseEvent, DetailedHTMLProps, HTMLAttributes } from 'react';
 import URL from 'url-parse';
 import Dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -16,8 +7,6 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { EnrichedUser, UR } from 'getstream';
 import { TDateTimeParser } from '../i18n/Streami18n';
 import { DefaultUT } from '../context/StreamApp';
-import isEqual from 'lodash/isEqual';
-
 Dayjs.extend(utc);
 Dayjs.extend(minMax);
 Dayjs.extend(relativeTime);
@@ -198,16 +187,6 @@ export const useOnClickUser = <
 
 export type PropsWithElementAttributes<T extends UR = UR, E extends HTMLElement = HTMLDivElement> = T &
   Pick<DetailedHTMLProps<HTMLAttributes<E>, E>, 'className' | 'style'>;
-
-export const useDeepCompareEffect = <D extends DependencyList>(effect: EffectCallback, dependencies: D) => {
-  const reference = useRef<D | undefined>();
-
-  if (!reference.current || !isEqual(dependencies, reference.current)) {
-    reference.current = dependencies;
-  }
-
-  useEffect(effect, reference.current);
-};
 
 export * from './textRenderer';
 export * from './smartRender';


### PR DESCRIPTION
Changing `options` property in either `FlatFeed` or `NotificationFeed` would not trigger re-fetch with newly updated options. Moved refresh to `Feed`, added `Lodash.isEqual` to compare if anything changed and added this reference to it's own effect dependency array. Also added `notify` property to trigger subscribe/unsubscribe effect.