### PR TITLE
Handle string timestamps with timezone in format ±hh:mm

### DIFF
--- a/src/utils/index.test.tsx
+++ b/src/utils/index.test.tsx
@@ -86,16 +86,22 @@ describe('utils', () => {
   });
 
   describe('humanizeTimestamp', () => {
-    it('correct toISOString timestamp', () => {
+    it('correct toISOString timestamp with Z', () => {
       const now = new Date().toISOString();
       expect(humanizeTimestamp(now, Dayjs)).toEqual('a few seconds ago');
       expect(humanizeTimestamp(now, moment)).toEqual('a few seconds ago');
     });
 
-    it('toISOString timestamp with Z', () => {
+    it('correct toISOString no timestamp', () => {
       const now = new Date().toISOString();
       expect(humanizeTimestamp(now.substring(0, now.length - 2), Dayjs)).toEqual('a few seconds ago');
       expect(humanizeTimestamp(now.substring(0, now.length - 2), moment)).toEqual('a few seconds ago');
     });
+
+    it('correct toISOString timestamp with +00:00', () => {
+      const now = new Date().toISOString().replace('Z', '+00:00');
+      expect(humanizeTimestamp(now, Dayjs)).toEqual('a few seconds ago');
+      expect(humanizeTimestamp(now, moment)).toEqual('a few seconds ago');
+    })
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,14 +11,18 @@ Dayjs.extend(utc);
 Dayjs.extend(minMax);
 Dayjs.extend(relativeTime);
 
+function isTimezoneAwareTimestamp(timestamp: string) {
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3,6}(Z$|[+-]\d{2}:\d{2}$)/.test(timestamp)
+}
+
 export function humanizeTimestamp(timestamp: string | number | Date, tDateTimeParser: TDateTimeParser) {
   let time;
   // Following calculation is based on assumption that tDateTimeParser()
   // either returns momentjs or dayjs object.
 
-  // When timestamp doesn't have z at the end, we are supposed to take it as UTC time.
+  // When timestamp is not timezone-aware, we are supposed to take it as UTC time.
   // Ideally we need to adhere to RFC3339. Unfortunately this needs to be fixed on backend.
-  if (typeof timestamp === 'string' && timestamp[timestamp.length - 1].toLowerCase() === 'z') {
+  if (typeof timestamp === 'string' && isTimezoneAwareTimestamp(timestamp)) {
     time = tDateTimeParser(timestamp);
   } else {
     time = tDateTimeParser(timestamp).add(Dayjs(timestamp).utcOffset(), 'minute'); // parse time as UTC


### PR DESCRIPTION
Updated the `humanizeTimestamp` function to properly handle string timestamps with the timezone in format `±hh:mm` which is also [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)-compliant

Reason for the change:

The [python](https://github.com/GetStream/stream-python/) SDK returns `activity.time` as a `datetime.datetime` object in [`feed.get`](https://getstream.io/activity-feeds/docs/python/adding_activities/?language=python#retrieving-activities), when these objects are sent as part of a JSON API payload they get converted to an ISO string with timezone in format `±hh:mm`
```python
>>> datetime.datetime(2021, 12, 6, 22, 35, 43, 345000, tzinfo=pytz.UTC).isoformat()
'2021-12-06T22:35:43.345000+00:00'
```