### PR TITLE
Fix: Forward doReactionsFilterRequest prop within NotificationFeed

### DIFF
--- a/src/components/NotificationFeed.tsx
+++ b/src/components/NotificationFeed.tsx
@@ -142,6 +142,7 @@ export const NotificationFeed = <
   doChildReactionDeleteRequest,
   doReactionAddRequest,
   doReactionDeleteRequest,
+  doReactionsFilterRequest,
   feedGroup = 'notification',
   notify = false,
   Group = Notification,
@@ -163,6 +164,7 @@ export const NotificationFeed = <
       doReactionDeleteRequest={doReactionDeleteRequest}
       doChildReactionAddRequest={doChildReactionAddRequest}
       doChildReactionDeleteRequest={doChildReactionDeleteRequest}
+      doReactionsFilterRequest={doReactionsFilterRequest}
     >
       <NotificationFeedInner<UT, AT, CT, RT, CRT, PT>
         Group={Group}


### PR DESCRIPTION
Forward doReactionsFilterRequest prop within NotificationFeed analogously to FlatFeed so that the activity reactions pagination requests can be customized.